### PR TITLE
Add live download progress updates

### DIFF
--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -197,6 +197,67 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
         Assert.Equal(1, result.TotalCount);
     }
 
+    [Fact]
+    public async Task DownloadQueueItemRepository_GetByRunId_ExcludesGroupLeavesAndReturnsVisibleGroupProgress()
+    {
+        var profileRepository = new SftpConnectionProfileRepository(_fixture.DataSource);
+        var jobRepository = new SporeSyncJobRepository(_fixture.DataSource);
+        var runRepository = new SporeSyncRunRepository(_fixture.DataSource);
+        var queueRepository = new DownloadQueueItemRepository(_fixture.DataSource);
+
+        var profile = await profileRepository.UpsertAsync(CreateProfile());
+        var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
+        var run = await runRepository.CreateAsync(job.Id);
+
+        var group = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
+        {
+            JobId = job.Id,
+            SyncRunId = run.Id,
+            RemotePath = "/incoming/group/",
+            DestinationPath = "/local/incoming/group",
+            FileSizeBytes = 300,
+            RemoteModifiedAt = DateTimeOffset.UtcNow,
+            IsGroup = true,
+            GroupRemotePath = null,
+            ChildCount = 2
+        });
+        await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
+        {
+            JobId = job.Id,
+            SyncRunId = run.Id,
+            RemotePath = "/incoming/group/a.csv",
+            DestinationPath = "/local/incoming/group/a.csv",
+            FileSizeBytes = 100,
+            RemoteModifiedAt = DateTimeOffset.UtcNow,
+            IsGroup = false,
+            GroupRemotePath = group.RemotePath,
+            ChildCount = 0
+        });
+
+        var visibleProgress = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+        {
+            Id = group.Id,
+            Status = "downloading",
+            BytesDownloaded = 75
+        });
+
+        var result = await queueRepository.GetByRunIdAsync(run.Id, new QueueItemQuery
+        {
+            PageNumber = 1,
+            PageSize = 10,
+            SortBy = "queuedAt",
+            SortDirection = "asc"
+        });
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(group.Id, item.Id);
+        Assert.True(item.IsGroup);
+        Assert.Null(item.GroupRemotePath);
+        Assert.Equal(75, visibleProgress.BytesDownloaded);
+        Assert.Equal(75, item.BytesDownloaded);
+        Assert.Equal(1, result.TotalCount);
+    }
+
     private static SftpConnectionProfile CreateProfile()
     {
         return new SftpConnectionProfile
@@ -389,6 +450,53 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
         var syncedState = await queueRepository.GetSyncedStateAsync(job.Id);
         Assert.True(syncedState.ContainsKey("/remote/incoming/file.txt"));
         Assert.Equal("queued", syncedState["/remote/incoming/file.txt"].Status);
+    }
+
+    [Fact]
+    public async Task DownloadQueueItemRepository_UpdateProgress_DoesNotRegressTerminalItemToDownloading()
+    {
+        var profileRepository = new SftpConnectionProfileRepository(_fixture.DataSource);
+        var jobRepository = new SporeSyncJobRepository(_fixture.DataSource);
+        var runRepository = new SporeSyncRunRepository(_fixture.DataSource);
+        var queueRepository = new DownloadQueueItemRepository(_fixture.DataSource);
+
+        var profile = await profileRepository.UpsertAsync(CreateProfile());
+        var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
+        var run = await runRepository.CreateAsync(job.Id);
+        var item = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
+        {
+            JobId = job.Id,
+            SyncRunId = run.Id,
+            RemotePath = "/incoming/race.csv",
+            DestinationPath = "/local/incoming/race.csv",
+            FileSizeBytes = 100,
+            RemoteModifiedAt = DateTimeOffset.UtcNow,
+            IsGroup = false,
+            ChildCount = 0
+        });
+
+        var completed = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+        {
+            Id = item.Id,
+            Status = "completed",
+            BytesDownloaded = 100,
+            CurrentBytesPerSecond = 25
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+            {
+                Id = item.Id,
+                Status = "downloading",
+                BytesDownloaded = 50
+            }));
+
+        var afterLateProgress = await queueRepository.GetByIdAsync(item.Id);
+        Assert.NotNull(afterLateProgress);
+        Assert.Equal("completed", afterLateProgress.Status);
+        Assert.Equal(completed.CompletedAt, afterLateProgress.CompletedAt);
+        Assert.Equal(100, afterLateProgress.BytesDownloaded);
+        Assert.Equal(25, afterLateProgress.CurrentBytesPerSecond);
     }
 
     [Fact]

--- a/SporeSync.Business/Sftp/SftpFileDownloader.cs
+++ b/SporeSync.Business/Sftp/SftpFileDownloader.cs
@@ -25,6 +25,7 @@ public sealed class SftpFileDownloader
         Guid connectionProfileId,
         string remotePath,
         string localPath,
+        IProgress<long>? progress = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -61,7 +62,25 @@ public sealed class SftpFileDownloader
         {
             await using var remoteStream = client.OpenRead(remotePath);
             await using var localStream = File.Create(tempPath);
-            await remoteStream.CopyToAsync(localStream, cancellationToken);
+            const int bufferSize = 81920;
+            var buffer = new byte[bufferSize];
+            long totalRead = 0;
+            int bytesRead;
+            var lastReportSw = Stopwatch.StartNew();
+            while ((bytesRead = await remoteStream.ReadAsync(buffer.AsMemory(0, bufferSize), cancellationToken)) > 0)
+            {
+                await localStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+                totalRead += bytesRead;
+                if (progress is not null && lastReportSw.ElapsedMilliseconds >= 150)
+                {
+                    progress.Report(totalRead);
+                    lastReportSw.Restart();
+                }
+            }
+            if (progress is not null)
+            {
+                progress.Report(totalRead);
+            }
             localStream.Flush(true);
         }
         catch (Exception ex)

--- a/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
+++ b/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
@@ -121,33 +121,18 @@ public sealed class DownloadWorkerHostedService : BackgroundService
         ISyncDashboardNotifier notifier,
         CancellationToken cancellationToken)
     {
-        var progress = new Progress<long>(bytes =>
+        var progress = new FireAndForgetDownloadProgress(async (bytes, token) =>
         {
-            // Best-effort progress update; do not block download thread
-            _ = Task.Run(async () =>
+            var partial = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
             {
-                try
-                {
-                    var partial = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
-                    {
-                        Id = item.Id,
-                        Status = "downloading",
-                        BytesDownloaded = bytes,
-                        CurrentBytesPerSecond = null,
-                        ErrorMessage = null
-                    }, cancellationToken);
-                    await notifier.NotifyQueueItemUpdatedAsync(partial, cancellationToken);
-                }
-                catch (OperationCanceledException)
-                {
-                    // ignore
-                }
-                catch
-                {
-                    // best effort; ignore transient progress reporting errors
-                }
-            }, cancellationToken);
-        });
+                Id = item.Id,
+                Status = "downloading",
+                BytesDownloaded = bytes,
+                CurrentBytesPerSecond = null,
+                ErrorMessage = null
+            }, token);
+            await notifier.NotifyQueueItemUpdatedAsync(partial, token);
+        }, cancellationToken);
 
         var result = await downloader.DownloadAsync(
             job.ConnectionProfileId,
@@ -156,14 +141,14 @@ public sealed class DownloadWorkerHostedService : BackgroundService
             progress,
             cancellationToken);
 
-        return await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+        return await progress.CompleteAsync(token => queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
         {
             Id = item.Id,
             Status = result.Success ? "completed" : "failed",
             BytesDownloaded = result.BytesDownloaded,
             CurrentBytesPerSecond = result.BytesPerSecond,
             ErrorMessage = result.ErrorMessage
-        }, cancellationToken);
+        }, token));
     }
 
     private static async Task<DownloadQueueItem> ProcessGroupAsync(
@@ -191,30 +176,31 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                 continue;
             }
 
-            var leafProgress = new Progress<long>(bytes =>
+            var completedBeforeLeaf = groupBytesDownloaded;
+            var leafProgress = new FireAndForgetDownloadProgress(async (bytes, token) =>
             {
-                _ = Task.Run(async () =>
+                await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
                 {
-                    try
-                    {
-                        var partial = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
-                        {
-                            Id = leaf.Id,
-                            Status = "downloading",
-                            BytesDownloaded = bytes,
-                            CurrentBytesPerSecond = null,
-                            ErrorMessage = null
-                        }, cancellationToken);
-                        await notifier.NotifyQueueItemUpdatedAsync(partial, cancellationToken);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                    }
-                    catch
-                    {
-                    }
-                }, cancellationToken);
-            });
+                    Id = leaf.Id,
+                    Status = "downloading",
+                    BytesDownloaded = bytes,
+                    CurrentBytesPerSecond = null,
+                    ErrorMessage = null
+                }, token);
+
+                var visibleGroupBytes = Math.Min(
+                    groupItem.FileSizeBytes,
+                    completedBeforeLeaf + Math.Min(bytes, leaf.FileSizeBytes));
+                var groupPartial = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+                {
+                    Id = groupItem.Id,
+                    Status = "downloading",
+                    BytesDownloaded = visibleGroupBytes,
+                    CurrentBytesPerSecond = null,
+                    ErrorMessage = null
+                }, token);
+                await notifier.NotifyQueueItemUpdatedAsync(groupPartial, token);
+            }, cancellationToken);
 
             var leafResult = await downloader.DownloadAsync(
                 job.ConnectionProfileId,
@@ -223,14 +209,14 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                 leafProgress,
                 cancellationToken);
 
-            var updatedLeaf = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+            await leafProgress.CompleteAsync(token => queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
             {
                 Id = leaf.Id,
                 Status = leafResult.Success ? "completed" : "failed",
                 BytesDownloaded = leafResult.BytesDownloaded,
                 CurrentBytesPerSecond = leafResult.BytesPerSecond,
                 ErrorMessage = leafResult.ErrorMessage
-            }, cancellationToken);
+            }, token));
 
             if (leafResult.Success)
             {
@@ -251,5 +237,73 @@ public sealed class DownloadWorkerHostedService : BackgroundService
             CurrentBytesPerSecond = latestRate,
             ErrorMessage = groupFailed ? "One or more files in the group failed to download." : null
         }, cancellationToken);
+    }
+
+    private sealed class FireAndForgetDownloadProgress : IProgress<long>
+    {
+        private readonly Func<long, CancellationToken, Task> _reportAsync;
+        private readonly CancellationToken _cancellationToken;
+        private readonly SemaphoreSlim _gate = new(1, 1);
+        private int _terminalUpdateStarted;
+
+        public FireAndForgetDownloadProgress(
+            Func<long, CancellationToken, Task> reportAsync,
+            CancellationToken cancellationToken)
+        {
+            _reportAsync = reportAsync;
+            _cancellationToken = cancellationToken;
+        }
+
+        public void Report(long bytesDownloaded)
+        {
+            if (Volatile.Read(ref _terminalUpdateStarted) != 0)
+            {
+                return;
+            }
+
+            _ = ReportAsync(bytesDownloaded);
+        }
+
+        public async Task<T> CompleteAsync<T>(Func<CancellationToken, Task<T>> terminalUpdateAsync)
+        {
+            Interlocked.Exchange(ref _terminalUpdateStarted, 1);
+            await _gate.WaitAsync(_cancellationToken);
+            try
+            {
+                return await terminalUpdateAsync(_cancellationToken);
+            }
+            finally
+            {
+                _gate.Release();
+            }
+        }
+
+        private async Task ReportAsync(long bytesDownloaded)
+        {
+            try
+            {
+                await _gate.WaitAsync(_cancellationToken);
+                try
+                {
+                    if (Volatile.Read(ref _terminalUpdateStarted) != 0)
+                    {
+                        return;
+                    }
+
+                    await _reportAsync(bytesDownloaded, _cancellationToken);
+                }
+                finally
+                {
+                    _gate.Release();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch
+            {
+                // Best-effort progress reporting must not fail or strand the download.
+            }
+        }
     }
 }

--- a/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
+++ b/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
@@ -121,10 +121,39 @@ public sealed class DownloadWorkerHostedService : BackgroundService
         ISyncDashboardNotifier notifier,
         CancellationToken cancellationToken)
     {
+        var progress = new Progress<long>(bytes =>
+        {
+            // Best-effort progress update; do not block download thread
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var partial = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+                    {
+                        Id = item.Id,
+                        Status = "downloading",
+                        BytesDownloaded = bytes,
+                        CurrentBytesPerSecond = null,
+                        ErrorMessage = null
+                    }, cancellationToken);
+                    await notifier.NotifyQueueItemUpdatedAsync(partial, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // ignore
+                }
+                catch
+                {
+                    // best effort; ignore transient progress reporting errors
+                }
+            }, cancellationToken);
+        });
+
         var result = await downloader.DownloadAsync(
             job.ConnectionProfileId,
             item.RemotePath,
             item.DestinationPath,
+            progress,
             cancellationToken);
 
         return await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
@@ -162,10 +191,36 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                 continue;
             }
 
+            var leafProgress = new Progress<long>(bytes =>
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var partial = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+                        {
+                            Id = leaf.Id,
+                            Status = "downloading",
+                            BytesDownloaded = bytes,
+                            CurrentBytesPerSecond = null,
+                            ErrorMessage = null
+                        }, cancellationToken);
+                        await notifier.NotifyQueueItemUpdatedAsync(partial, cancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                    catch
+                    {
+                    }
+                }, cancellationToken);
+            });
+
             var leafResult = await downloader.DownloadAsync(
                 job.ConnectionProfileId,
                 leaf.RemotePath,
                 leaf.DestinationPath,
+                leafProgress,
                 cancellationToken);
 
             var updatedLeaf = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress

--- a/SporeSync.Infrastructure/Migrations/GuardTerminalDownloadProgressMigration.cs
+++ b/SporeSync.Infrastructure/Migrations/GuardTerminalDownloadProgressMigration.cs
@@ -1,0 +1,30 @@
+using FluentMigrator;
+
+namespace SporeSync.Infrastructure.Migrations;
+
+[Migration(202607110001)]
+public sealed class GuardTerminalDownloadProgressMigration : Migration
+{
+    private const string UpScript = "SporeSync.Infrastructure.Migrations.Schema.202607110001_GuardTerminalDownloadProgress_up.sql";
+    private const string DownScript = "SporeSync.Infrastructure.Migrations.Schema.202607110001_GuardTerminalDownloadProgress_down.sql";
+
+    public override void Up()
+    {
+        Execute.Sql(ReadEmbeddedScript(UpScript));
+    }
+
+    public override void Down()
+    {
+        Execute.Sql(ReadEmbeddedScript(DownScript));
+    }
+
+    private static string ReadEmbeddedScript(string resourceName)
+    {
+        var assembly = typeof(GuardTerminalDownloadProgressMigration).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded migration script '{resourceName}' was not found.");
+        using var reader = new StreamReader(stream);
+
+        return reader.ReadToEnd();
+    }
+}

--- a/SporeSync.Infrastructure/Migrations/Schema/202607110001_GuardTerminalDownloadProgress_down.sql
+++ b/SporeSync.Infrastructure/Migrations/Schema/202607110001_GuardTerminalDownloadProgress_down.sql
@@ -1,0 +1,63 @@
+CREATE OR REPLACE FUNCTION core.update_download_queue_item_progress(
+    p_id uuid,
+    p_status varchar(32),
+    p_bytes_downloaded bigint,
+    p_current_bytes_per_second numeric,
+    p_error_message text,
+    p_handled_reason varchar(100))
+RETURNS TABLE (
+    id uuid,
+    job_id uuid,
+    sync_run_id uuid,
+    remote_path varchar(2000),
+    destination_path varchar(2000),
+    file_size_bytes bigint,
+    remote_modified_at timestamptz,
+    status varchar(32),
+    bytes_downloaded bigint,
+    current_bytes_per_second numeric(20, 2),
+    retry_count integer,
+    handled_reason varchar(100),
+    error_message text,
+    queued_at timestamptz,
+    started_at timestamptz,
+    completed_at timestamptz,
+    updated_at timestamptz,
+    is_group boolean,
+    group_remote_path varchar(2000),
+    child_count integer)
+LANGUAGE sql
+AS $$
+    UPDATE core.download_queue_items AS qi
+    SET status = p_status,
+        bytes_downloaded = p_bytes_downloaded,
+        current_bytes_per_second = p_current_bytes_per_second,
+        error_message = p_error_message,
+        handled_reason = p_handled_reason,
+        completed_at = CASE
+            WHEN p_status IN ('completed', 'failed', 'skipped') THEN now()
+            ELSE qi.completed_at
+        END,
+        updated_at = now()
+    WHERE qi.id = p_id
+    RETURNING qi.id,
+              qi.job_id,
+              qi.sync_run_id,
+              qi.remote_path,
+              qi.destination_path,
+              qi.file_size_bytes,
+              qi.remote_modified_at,
+              qi.status,
+              qi.bytes_downloaded,
+              qi.current_bytes_per_second,
+              qi.retry_count,
+              qi.handled_reason,
+              qi.error_message,
+              qi.queued_at,
+              qi.started_at,
+              qi.completed_at,
+              qi.updated_at,
+              qi.is_group,
+              qi.group_remote_path,
+              qi.child_count;
+$$;

--- a/SporeSync.Infrastructure/Migrations/Schema/202607110001_GuardTerminalDownloadProgress_up.sql
+++ b/SporeSync.Infrastructure/Migrations/Schema/202607110001_GuardTerminalDownloadProgress_up.sql
@@ -1,0 +1,67 @@
+CREATE OR REPLACE FUNCTION core.update_download_queue_item_progress(
+    p_id uuid,
+    p_status varchar(32),
+    p_bytes_downloaded bigint,
+    p_current_bytes_per_second numeric,
+    p_error_message text,
+    p_handled_reason varchar(100))
+RETURNS TABLE (
+    id uuid,
+    job_id uuid,
+    sync_run_id uuid,
+    remote_path varchar(2000),
+    destination_path varchar(2000),
+    file_size_bytes bigint,
+    remote_modified_at timestamptz,
+    status varchar(32),
+    bytes_downloaded bigint,
+    current_bytes_per_second numeric(20, 2),
+    retry_count integer,
+    handled_reason varchar(100),
+    error_message text,
+    queued_at timestamptz,
+    started_at timestamptz,
+    completed_at timestamptz,
+    updated_at timestamptz,
+    is_group boolean,
+    group_remote_path varchar(2000),
+    child_count integer)
+LANGUAGE sql
+AS $$
+    UPDATE core.download_queue_items AS qi
+    SET status = p_status,
+        bytes_downloaded = p_bytes_downloaded,
+        current_bytes_per_second = p_current_bytes_per_second,
+        error_message = p_error_message,
+        handled_reason = p_handled_reason,
+        completed_at = CASE
+            WHEN p_status IN ('completed', 'failed', 'skipped') THEN now()
+            ELSE qi.completed_at
+        END,
+        updated_at = now()
+    WHERE qi.id = p_id
+      AND (
+          p_status IN ('completed', 'failed', 'skipped')
+          OR qi.status NOT IN ('completed', 'failed', 'skipped')
+      )
+    RETURNING qi.id,
+              qi.job_id,
+              qi.sync_run_id,
+              qi.remote_path,
+              qi.destination_path,
+              qi.file_size_bytes,
+              qi.remote_modified_at,
+              qi.status,
+              qi.bytes_downloaded,
+              qi.current_bytes_per_second,
+              qi.retry_count,
+              qi.handled_reason,
+              qi.error_message,
+              qi.queued_at,
+              qi.started_at,
+              qi.completed_at,
+              qi.updated_at,
+              qi.is_group,
+              qi.group_remote_path,
+              qi.child_count;
+$$;

--- a/SporeSync.Web/ClientApp/src/api/cacheUpdates.test.ts
+++ b/SporeSync.Web/ClientApp/src/api/cacheUpdates.test.ts
@@ -1,7 +1,10 @@
 import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
-import { upsertRunInPagedCaches } from "./cacheUpdates";
-import type { PagedResponse, SporeSyncRun } from "./types";
+import {
+  upsertQueueItemInPagedCaches,
+  upsertRunInPagedCaches,
+} from "./cacheUpdates";
+import type { DownloadQueueItem, PagedResponse, SporeSyncRun } from "./types";
 
 function makeRun(id: string, status: string): SporeSyncRun {
   return {
@@ -19,6 +22,35 @@ function makeRun(id: string, status: string): SporeSyncRun {
     downloadedBytes: 0,
     currentBytesPerSecond: null,
     errorMessage: null,
+  };
+}
+
+function makeQueueItem(
+  id: string,
+  overrides: Partial<DownloadQueueItem> = {},
+): DownloadQueueItem {
+  return {
+    id,
+    jobId: "job-1",
+    syncRunId: "run-1",
+    remotePath: "/incoming/file.csv",
+    destinationPath: "/local/incoming/file.csv",
+    fileSizeBytes: 100,
+    remoteModifiedAt: null,
+    status: "downloading",
+    bytesDownloaded: 0,
+    currentBytesPerSecond: null,
+    retryCount: 0,
+    handledReason: null,
+    errorMessage: null,
+    queuedAt: "2026-05-27T12:00:00Z",
+    startedAt: null,
+    completedAt: null,
+    updatedAt: "2026-05-27T12:00:00Z",
+    isGroup: false,
+    groupRemotePath: null,
+    childCount: 0,
+    ...overrides,
   };
 }
 
@@ -46,5 +78,72 @@ describe("cache updates", () => {
         { pageNumber: 1 },
       ])?.items[0],
     ).toEqual(running);
+  });
+
+  it("does not insert hidden group leaves into queue item pages", () => {
+    const queryClient = new QueryClient();
+    const group = makeQueueItem("group-1", {
+      remotePath: "/incoming/group/",
+      destinationPath: "/local/incoming/group",
+      isGroup: true,
+      childCount: 2,
+    });
+    const leaf = makeQueueItem("leaf-1", {
+      remotePath: "/incoming/group/a.csv",
+      destinationPath: "/local/incoming/group/a.csv",
+      groupRemotePath: "/incoming/group/",
+    });
+    const page: PagedResponse<DownloadQueueItem> = {
+      items: [group],
+      pageNumber: 1,
+      pageSize: 25,
+      totalCount: 1,
+    };
+
+    queryClient.setQueryData(["runs", "run-1", "queue-items"], page);
+    upsertQueueItemInPagedCaches(queryClient, leaf);
+
+    expect(
+      queryClient.getQueryData<PagedResponse<DownloadQueueItem>>([
+        "runs",
+        "run-1",
+        "queue-items",
+      ])?.items,
+    ).toEqual([group]);
+  });
+
+  it("updates visible group progress in queue item pages", () => {
+    const queryClient = new QueryClient();
+    const group = makeQueueItem("group-1", {
+      remotePath: "/incoming/group/",
+      destinationPath: "/local/incoming/group",
+      isGroup: true,
+      childCount: 2,
+    });
+    const updatedGroup = makeQueueItem("group-1", {
+      remotePath: "/incoming/group/",
+      destinationPath: "/local/incoming/group",
+      status: "downloading",
+      bytesDownloaded: 60,
+      isGroup: true,
+      childCount: 2,
+    });
+    const page: PagedResponse<DownloadQueueItem> = {
+      items: [group],
+      pageNumber: 1,
+      pageSize: 25,
+      totalCount: 1,
+    };
+
+    queryClient.setQueryData(["runs", "run-1", "queue-items"], page);
+    upsertQueueItemInPagedCaches(queryClient, updatedGroup);
+
+    expect(
+      queryClient.getQueryData<PagedResponse<DownloadQueueItem>>([
+        "runs",
+        "run-1",
+        "queue-items",
+      ])?.items[0],
+    ).toEqual(updatedGroup);
   });
 });

--- a/SporeSync.Web/ClientApp/src/api/cacheUpdates.ts
+++ b/SporeSync.Web/ClientApp/src/api/cacheUpdates.ts
@@ -33,11 +33,20 @@ export function upsertQueueItemInPagedCaches(
     return;
   }
 
+  const isHiddenGroupLeaf = !item.isGroup && item.groupRemotePath !== null;
+
   queryClient.setQueriesData<PagedResponse<DownloadQueueItem>>(
     { queryKey: ["runs", item.syncRunId, "queue-items"] },
     (page) => {
       if (!page) {
         return page;
+      }
+
+      if (isHiddenGroupLeaf) {
+        return {
+          ...page,
+          items: page.items.filter((existing) => existing.id !== item.id),
+        };
       }
 
       const exists = page.items.some((existing) => existing.id === item.id);


### PR DESCRIPTION
## Summary
- Adds byte-level progress reporting to `SftpFileDownloader` during SFTP transfers.
- Updates download worker processing to publish partial queue item progress while files are downloading.
- Sends best-effort notifier updates as progress changes, while keeping the final completion update flow intact.

## Testing
- Not run (not requested).
- Not run: `npm run biome:check`.
- Not run: `npm test`.