### PR TITLE
Add single-admin authentication for API, SPA, and SignalR hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SporeSync is an ASP.NET Core application with a React/Vite single-page app for m
 - ASP.NET Core web API and static SPA hosting
 - React, TypeScript, Vite, TanStack Router, and TanStack Query frontend
 - SignalR dashboard updates
+- Single-admin cookie authentication for the API, SPA, and SignalR hub (see [docs/authentication.md](docs/authentication.md))
 - PostgreSQL persistence with FluentMigrator migrations
 - Real SFTP sync worker: scheduled job polling, incremental scan/enqueue, serial download to local filesystem
 - Backend-driven first-child opaque folder grouping: large directories appear as a small number of logical rows in the dashboard with subtree aggregates (see specs/folder-grouping-implementation-plan.html and specs/grouping-rules.md)
@@ -105,6 +106,22 @@ Worker settings in `appsettings.json`:
   }
 }
 ```
+
+### Authentication
+
+The app is protected by a single admin login (cookie sessions) covering the
+REST API, the SPA, and the `/hubs/dashboard` SignalR hub. Authentication is
+enabled by default outside Development and the app refuses to start until an
+admin credential is configured:
+
+```bash
+# Generate a PBKDF2 hash for Auth:PasswordHash / Auth__PasswordHash
+dotnet run --project SporeSync.Web/SporeSync.Web.csproj -- hash-password
+```
+
+`appsettings.Development.json` disables authentication so local development
+works without a login. See [docs/authentication.md](docs/authentication.md)
+for all settings, the login flow, and deployment examples.
 
 ## Common Commands
 

--- a/SporeSync.Business.Tests/AdminCredentialValidatorTests.cs
+++ b/SporeSync.Business.Tests/AdminCredentialValidatorTests.cs
@@ -1,0 +1,79 @@
+using SporeSync.Web.Auth;
+
+namespace SporeSync.Business.Tests;
+
+public sealed class AdminCredentialValidatorTests
+{
+    [Fact]
+    public void Validate_ReturnsTrue_ForCorrectPlaintextCredentials()
+    {
+        var validator = new AdminCredentialValidator(new AuthOptions
+        {
+            Enabled = true,
+            Username = "admin",
+            Password = "s3cret"
+        });
+
+        Assert.True(validator.Validate("admin", "s3cret"));
+    }
+
+    [Fact]
+    public void Validate_ReturnsTrue_ForCorrectHashedCredentials()
+    {
+        var validator = new AdminCredentialValidator(new AuthOptions
+        {
+            Enabled = true,
+            Username = "admin",
+            PasswordHash = PasswordHasher.Hash("s3cret")
+        });
+
+        Assert.True(validator.Validate("admin", "s3cret"));
+    }
+
+    [Fact]
+    public void Validate_PrefersHash_WhenBothPasswordAndHashAreSet()
+    {
+        var validator = new AdminCredentialValidator(new AuthOptions
+        {
+            Enabled = true,
+            Username = "admin",
+            Password = "plaintext-password",
+            PasswordHash = PasswordHasher.Hash("hashed-password")
+        });
+
+        Assert.True(validator.Validate("admin", "hashed-password"));
+        Assert.False(validator.Validate("admin", "plaintext-password"));
+    }
+
+    [Theory]
+    [InlineData("admin", "wrong")]
+    [InlineData("root", "s3cret")]
+    [InlineData("", "s3cret")]
+    [InlineData("admin", "")]
+    [InlineData(null, "s3cret")]
+    [InlineData("admin", null)]
+    public void Validate_ReturnsFalse_ForIncorrectOrMissingCredentials(string? username, string? password)
+    {
+        var validator = new AdminCredentialValidator(new AuthOptions
+        {
+            Enabled = true,
+            Username = "admin",
+            Password = "s3cret"
+        });
+
+        Assert.False(validator.Validate(username, password));
+    }
+
+    [Fact]
+    public void Validate_ReturnsFalse_WhenAuthDisabled()
+    {
+        var validator = new AdminCredentialValidator(new AuthOptions
+        {
+            Enabled = false,
+            Username = "admin",
+            Password = "s3cret"
+        });
+
+        Assert.False(validator.Validate("admin", "s3cret"));
+    }
+}

--- a/SporeSync.Business.Tests/AuthControllerTests.cs
+++ b/SporeSync.Business.Tests/AuthControllerTests.cs
@@ -1,0 +1,173 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using SporeSync.Web.Auth;
+using SporeSync.Web.Controllers;
+using SporeSync.Web.DTO;
+
+namespace SporeSync.Business.Tests;
+
+public sealed class AuthControllerTests
+{
+    [Fact]
+    public async Task Login_SignsInAndReturnsSession_ForValidCredentials()
+    {
+        var authenticationService = new FakeAuthenticationService();
+        var controller = CreateController(
+            new AuthOptions { Enabled = true, Username = "admin", Password = "s3cret" },
+            authenticationService);
+
+        var result = await controller.Login(new LoginRequest("admin", "s3cret"));
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var session = Assert.IsType<AuthSessionResponse>(ok.Value);
+        Assert.True(session.AuthRequired);
+        Assert.True(session.Authenticated);
+        Assert.Equal("admin", session.Username);
+        Assert.NotNull(authenticationService.SignedInPrincipal);
+        Assert.Equal("admin", authenticationService.SignedInPrincipal!.Identity?.Name);
+    }
+
+    [Fact]
+    public async Task Login_ReturnsUnauthorized_ForInvalidCredentials()
+    {
+        var authenticationService = new FakeAuthenticationService();
+        var controller = CreateController(
+            new AuthOptions { Enabled = true, Username = "admin", Password = "s3cret" },
+            authenticationService);
+
+        var result = await controller.Login(new LoginRequest("admin", "wrong"));
+
+        Assert.IsType<UnauthorizedObjectResult>(result.Result);
+        Assert.Null(authenticationService.SignedInPrincipal);
+    }
+
+    [Fact]
+    public async Task Login_DoesNotSignIn_WhenAuthDisabled()
+    {
+        var authenticationService = new FakeAuthenticationService();
+        var controller = CreateController(new AuthOptions { Enabled = false }, authenticationService);
+
+        var result = await controller.Login(new LoginRequest("anyone", "anything"));
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var session = Assert.IsType<AuthSessionResponse>(ok.Value);
+        Assert.False(session.AuthRequired);
+        Assert.True(session.Authenticated);
+        Assert.Null(authenticationService.SignedInPrincipal);
+    }
+
+    [Fact]
+    public void GetSession_ReportsUnauthenticated_WhenAuthEnabledAndAnonymous()
+    {
+        var controller = CreateController(
+            new AuthOptions { Enabled = true, Username = "admin", Password = "s3cret" },
+            new FakeAuthenticationService());
+
+        var result = controller.GetSession();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var session = Assert.IsType<AuthSessionResponse>(ok.Value);
+        Assert.True(session.AuthRequired);
+        Assert.False(session.Authenticated);
+        Assert.Null(session.Username);
+    }
+
+    [Fact]
+    public void GetSession_ReportsAuthenticated_ForSignedInUser()
+    {
+        var controller = CreateController(
+            new AuthOptions { Enabled = true, Username = "admin", Password = "s3cret" },
+            new FakeAuthenticationService());
+        controller.ControllerContext.HttpContext.User = new ClaimsPrincipal(
+            new ClaimsIdentity([new Claim(ClaimTypes.Name, "admin")], "Cookies"));
+
+        var result = controller.GetSession();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var session = Assert.IsType<AuthSessionResponse>(ok.Value);
+        Assert.True(session.AuthRequired);
+        Assert.True(session.Authenticated);
+        Assert.Equal("admin", session.Username);
+    }
+
+    [Fact]
+    public void GetSession_ReportsNoAuthRequired_WhenDisabled()
+    {
+        var controller = CreateController(new AuthOptions { Enabled = false }, new FakeAuthenticationService());
+
+        var result = controller.GetSession();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var session = Assert.IsType<AuthSessionResponse>(ok.Value);
+        Assert.False(session.AuthRequired);
+        Assert.True(session.Authenticated);
+    }
+
+    [Fact]
+    public async Task Logout_SignsOut()
+    {
+        var authenticationService = new FakeAuthenticationService();
+        var controller = CreateController(
+            new AuthOptions { Enabled = true, Username = "admin", Password = "s3cret" },
+            authenticationService);
+
+        var result = await controller.Logout();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var session = Assert.IsType<AuthSessionResponse>(ok.Value);
+        Assert.True(authenticationService.SignedOut);
+        Assert.True(session.AuthRequired);
+        Assert.False(session.Authenticated);
+    }
+
+    private static AuthController CreateController(
+        AuthOptions options,
+        FakeAuthenticationService authenticationService)
+    {
+        var services = new ServiceCollection()
+            .AddSingleton<IAuthenticationService>(authenticationService)
+            .BuildServiceProvider();
+
+        return new AuthController(
+            options,
+            new AdminCredentialValidator(options),
+            NullLogger<AuthController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { RequestServices = services }
+            }
+        };
+    }
+
+    private sealed class FakeAuthenticationService : IAuthenticationService
+    {
+        public ClaimsPrincipal? SignedInPrincipal { get; private set; }
+        public bool SignedOut { get; private set; }
+
+        public Task<AuthenticateResult> AuthenticateAsync(HttpContext context, string? scheme)
+            => Task.FromResult(AuthenticateResult.NoResult());
+
+        public Task ChallengeAsync(HttpContext context, string? scheme, AuthenticationProperties? properties)
+            => Task.CompletedTask;
+
+        public Task ForbidAsync(HttpContext context, string? scheme, AuthenticationProperties? properties)
+            => Task.CompletedTask;
+
+        public Task SignInAsync(HttpContext context, string? scheme, ClaimsPrincipal principal, AuthenticationProperties? properties)
+        {
+            SignedInPrincipal = principal;
+            return Task.CompletedTask;
+        }
+
+        public Task SignOutAsync(HttpContext context, string? scheme, AuthenticationProperties? properties)
+        {
+            SignedOut = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/SporeSync.Business.Tests/AuthOptionsTests.cs
+++ b/SporeSync.Business.Tests/AuthOptionsTests.cs
@@ -1,0 +1,66 @@
+using SporeSync.Web.Auth;
+
+namespace SporeSync.Business.Tests;
+
+public sealed class AuthOptionsTests
+{
+    [Fact]
+    public void Validate_Throws_WhenEnabledWithoutAnyCredential()
+    {
+        var options = new AuthOptions { Enabled = true, Username = "admin" };
+
+        var exception = Assert.Throws<InvalidOperationException>(options.Validate);
+        Assert.Contains("Auth:PasswordHash", exception.Message);
+    }
+
+    [Fact]
+    public void Validate_Throws_WhenEnabledWithoutUsername()
+    {
+        var options = new AuthOptions { Enabled = true, Username = " ", Password = "s3cret" };
+
+        var exception = Assert.Throws<InvalidOperationException>(options.Validate);
+        Assert.Contains("Auth:Username", exception.Message);
+    }
+
+    [Fact]
+    public void Validate_Throws_ForMalformedPasswordHash()
+    {
+        var options = new AuthOptions { Enabled = true, PasswordHash = "not-a-valid-hash" };
+
+        var exception = Assert.Throws<InvalidOperationException>(options.Validate);
+        Assert.Contains("Auth:PasswordHash", exception.Message);
+    }
+
+    [Fact]
+    public void Validate_Throws_ForNonPositiveSessionHours()
+    {
+        var options = new AuthOptions { Enabled = true, Password = "s3cret", SessionHours = 0 };
+
+        var exception = Assert.Throws<InvalidOperationException>(options.Validate);
+        Assert.Contains("Auth:SessionHours", exception.Message);
+    }
+
+    [Fact]
+    public void Validate_Succeeds_WhenDisabled_WithoutCredentials()
+    {
+        var options = new AuthOptions { Enabled = false };
+
+        options.Validate();
+    }
+
+    [Fact]
+    public void Validate_Succeeds_WithPlaintextPassword()
+    {
+        var options = new AuthOptions { Enabled = true, Password = "s3cret" };
+
+        options.Validate();
+    }
+
+    [Fact]
+    public void Validate_Succeeds_WithGeneratedPasswordHash()
+    {
+        var options = new AuthOptions { Enabled = true, PasswordHash = PasswordHasher.Hash("s3cret") };
+
+        options.Validate();
+    }
+}

--- a/SporeSync.Business.Tests/ForwardedHeaderSettingsTests.cs
+++ b/SporeSync.Business.Tests/ForwardedHeaderSettingsTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders;
+using SporeSync.Web.Security;
+
+namespace SporeSync.Business.Tests;
+
+public sealed class ForwardedHeaderSettingsTests
+{
+    [Fact]
+    public void Configure_TrustsOnlyExplicitProxiesAndNetworks()
+    {
+        var settings = new ForwardedHeaderSettings
+        {
+            Enabled = true,
+            KnownProxies = ["10.0.0.10"],
+            KnownNetworks = ["172.18.0.0/16"],
+            ForwardLimit = 1
+        };
+        var options = new ForwardedHeadersOptions();
+
+        settings.Configure(options);
+
+        Assert.Equal(ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto, options.ForwardedHeaders);
+        Assert.Equal(1, options.ForwardLimit);
+        Assert.True(options.RequireHeaderSymmetry);
+        Assert.Equal(IPAddress.Parse("10.0.0.10"), Assert.Single(options.KnownProxies));
+
+        var network = Assert.Single(options.KnownIPNetworks);
+        Assert.Equal(IPAddress.Parse("172.18.0.0"), network.BaseAddress);
+        Assert.Equal(16, network.PrefixLength);
+    }
+
+    [Fact]
+    public void Validate_RejectsEnabledConfigurationWithoutTrustedProxyOrNetwork()
+    {
+        var settings = new ForwardedHeaderSettings { Enabled = true };
+
+        var exception = Assert.Throws<InvalidOperationException>(settings.Validate);
+
+        Assert.Contains("no trusted proxy or network", exception.Message);
+    }
+
+    [Fact]
+    public void Validate_RejectsInvalidKnownProxy()
+    {
+        var settings = new ForwardedHeaderSettings
+        {
+            Enabled = true,
+            KnownProxies = ["not-an-ip"]
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(settings.Validate);
+
+        Assert.Contains("invalid IP address", exception.Message);
+    }
+
+    [Fact]
+    public void Validate_RejectsInvalidKnownNetwork()
+    {
+        var settings = new ForwardedHeaderSettings
+        {
+            Enabled = true,
+            KnownNetworks = ["172.18.0.0"]
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(settings.Validate);
+
+        Assert.Contains("invalid CIDR network", exception.Message);
+    }
+}

--- a/SporeSync.Business.Tests/PasswordHasherTests.cs
+++ b/SporeSync.Business.Tests/PasswordHasherTests.cs
@@ -1,0 +1,66 @@
+using SporeSync.Web.Auth;
+
+namespace SporeSync.Business.Tests;
+
+public sealed class PasswordHasherTests
+{
+    [Fact]
+    public void Verify_ReturnsTrue_ForCorrectPassword()
+    {
+        var hash = PasswordHasher.Hash("correct horse battery staple");
+
+        Assert.True(PasswordHasher.Verify("correct horse battery staple", hash));
+    }
+
+    [Fact]
+    public void Verify_ReturnsFalse_ForWrongPassword()
+    {
+        var hash = PasswordHasher.Hash("correct horse battery staple");
+
+        Assert.False(PasswordHasher.Verify("wrong password", hash));
+    }
+
+    [Fact]
+    public void Hash_ProducesUniqueSaltedHashes()
+    {
+        var first = PasswordHasher.Hash("password");
+        var second = PasswordHasher.Hash("password");
+
+        Assert.NotEqual(first, second);
+        Assert.True(PasswordHasher.Verify("password", first));
+        Assert.True(PasswordHasher.Verify("password", second));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-hash")]
+    [InlineData("PBKDF2-SHA256.abc.def.ghi")]
+    [InlineData("PBKDF2-SHA256.0.c2FsdA==.aGFzaA==")]
+    [InlineData("PBKDF2-SHA1.10000.c2FsdA==.aGFzaA==")]
+    [InlineData("PBKDF2-SHA256.10000.%%%.aGFzaA==")]
+    public void Verify_ReturnsFalse_ForMalformedStoredHash(string storedHash)
+    {
+        Assert.False(PasswordHasher.Verify("password", storedHash));
+        Assert.False(PasswordHasher.IsValidHashFormat(storedHash));
+    }
+
+    [Fact]
+    public void Verify_ReturnsFalse_ForEmptyPassword()
+    {
+        var hash = PasswordHasher.Hash("password");
+
+        Assert.False(PasswordHasher.Verify("", hash));
+    }
+
+    [Fact]
+    public void IsValidHashFormat_ReturnsTrue_ForGeneratedHash()
+    {
+        Assert.True(PasswordHasher.IsValidHashFormat(PasswordHasher.Hash("password")));
+    }
+
+    [Fact]
+    public void Hash_Throws_ForEmptyPassword()
+    {
+        Assert.Throws<ArgumentException>(() => PasswordHasher.Hash(""));
+    }
+}

--- a/SporeSync.Business.Tests/SporeSync.Business.Tests.csproj
+++ b/SporeSync.Business.Tests/SporeSync.Business.Tests.csproj
@@ -30,4 +30,8 @@
     <ProjectReference Include="..\SporeSync.Web\SporeSync.Web.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 </Project>

--- a/SporeSync.Web/Auth/AdminCredentialValidator.cs
+++ b/SporeSync.Web/Auth/AdminCredentialValidator.cs
@@ -1,0 +1,44 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace SporeSync.Web.Auth;
+
+/// <summary>
+/// Validates login attempts against the configured single admin credential.
+/// </summary>
+public sealed class AdminCredentialValidator
+{
+    private readonly AuthOptions _options;
+
+    public AdminCredentialValidator(AuthOptions options)
+    {
+        _options = options;
+    }
+
+    public bool Validate(string? username, string? password)
+    {
+        if (!_options.Enabled || string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+        {
+            return false;
+        }
+
+        var usernameMatches = FixedTimeEquals(username, _options.Username);
+
+        // Always run the password check so response timing does not reveal
+        // whether the username was correct.
+        var passwordMatches = !string.IsNullOrEmpty(_options.PasswordHash)
+            ? PasswordHasher.Verify(password, _options.PasswordHash)
+            : FixedTimeEquals(password, _options.Password);
+
+        return usernameMatches && passwordMatches;
+    }
+
+    private static bool FixedTimeEquals(string left, string right)
+    {
+        var leftBytes = Encoding.UTF8.GetBytes(left);
+        var rightBytes = Encoding.UTF8.GetBytes(right);
+
+        return leftBytes.Length == rightBytes.Length
+            && CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
+    }
+}

--- a/SporeSync.Web/Auth/AuthOptions.cs
+++ b/SporeSync.Web/Auth/AuthOptions.cs
@@ -1,0 +1,66 @@
+namespace SporeSync.Web.Auth;
+
+/// <summary>
+/// Configuration for the single-admin authentication scheme, bound from the "Auth" section.
+/// </summary>
+public sealed class AuthOptions
+{
+    public const string SectionName = "Auth";
+
+    /// <summary>Whether login is required for API, SPA data, and SignalR access.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>The single admin username.</summary>
+    public string Username { get; set; } = "admin";
+
+    /// <summary>
+    /// Plaintext admin password. Intended for local development only;
+    /// prefer <see cref="PasswordHash"/> in real deployments.
+    /// </summary>
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// PBKDF2 password hash produced by <c>dotnet run --project SporeSync.Web -- hash-password</c>.
+    /// Takes precedence over <see cref="Password"/> when both are set.
+    /// </summary>
+    public string PasswordHash { get; set; } = string.Empty;
+
+    /// <summary>Sliding session lifetime for the auth cookie, in hours.</summary>
+    public double SessionHours { get; set; } = 12;
+
+    public void Validate()
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Username))
+        {
+            throw new InvalidOperationException(
+                "Authentication is enabled but Auth:Username is empty. " +
+                "Set Auth:Username (environment variable Auth__Username) or disable authentication with Auth:Enabled=false.");
+        }
+
+        if (string.IsNullOrEmpty(Password) && string.IsNullOrEmpty(PasswordHash))
+        {
+            throw new InvalidOperationException(
+                "Authentication is enabled but no admin credential is configured. " +
+                "Set Auth:PasswordHash (environment variable Auth__PasswordHash) to a hash generated with " +
+                "'dotnet run --project SporeSync.Web -- hash-password', set Auth:Password for local development, " +
+                "or disable authentication with Auth:Enabled=false.");
+        }
+
+        if (!string.IsNullOrEmpty(PasswordHash) && !PasswordHasher.IsValidHashFormat(PasswordHash))
+        {
+            throw new InvalidOperationException(
+                "Auth:PasswordHash is not in the expected format. Generate a value with " +
+                "'dotnet run --project SporeSync.Web -- hash-password'.");
+        }
+
+        if (SessionHours <= 0)
+        {
+            throw new InvalidOperationException("Auth:SessionHours must be greater than zero.");
+        }
+    }
+}

--- a/SporeSync.Web/Auth/PasswordHasher.cs
+++ b/SporeSync.Web/Auth/PasswordHasher.cs
@@ -1,0 +1,77 @@
+using System.Security.Cryptography;
+
+namespace SporeSync.Web.Auth;
+
+/// <summary>
+/// PBKDF2-SHA256 password hashing for the single admin credential.
+/// Hash format: <c>PBKDF2-SHA256.{iterations}.{saltBase64}.{hashBase64}</c>.
+/// </summary>
+public static class PasswordHasher
+{
+    private const string Prefix = "PBKDF2-SHA256";
+    private const int DefaultIterations = 210_000;
+    private const int SaltSizeBytes = 16;
+    private const int HashSizeBytes = 32;
+
+    public static string Hash(string password, int iterations = DefaultIterations)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(password);
+        ArgumentOutOfRangeException.ThrowIfLessThan(iterations, 1);
+
+        var salt = RandomNumberGenerator.GetBytes(SaltSizeBytes);
+        var hash = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, HashAlgorithmName.SHA256, HashSizeBytes);
+
+        return $"{Prefix}.{iterations}.{Convert.ToBase64String(salt)}.{Convert.ToBase64String(hash)}";
+    }
+
+    public static bool Verify(string password, string storedHash)
+    {
+        if (string.IsNullOrEmpty(password) || !TryParse(storedHash, out var iterations, out var salt, out var expectedHash))
+        {
+            return false;
+        }
+
+        var actualHash = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, HashAlgorithmName.SHA256, expectedHash.Length);
+        return CryptographicOperations.FixedTimeEquals(actualHash, expectedHash);
+    }
+
+    public static bool IsValidHashFormat(string storedHash)
+    {
+        return TryParse(storedHash, out _, out _, out _);
+    }
+
+    private static bool TryParse(string storedHash, out int iterations, out byte[] salt, out byte[] hash)
+    {
+        iterations = 0;
+        salt = [];
+        hash = [];
+
+        if (string.IsNullOrEmpty(storedHash))
+        {
+            return false;
+        }
+
+        var parts = storedHash.Split('.');
+        if (parts.Length != 4 || parts[0] != Prefix)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(parts[1], out iterations) || iterations < 1)
+        {
+            return false;
+        }
+
+        try
+        {
+            salt = Convert.FromBase64String(parts[2]);
+            hash = Convert.FromBase64String(parts[3]);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        return salt.Length > 0 && hash.Length > 0;
+    }
+}

--- a/SporeSync.Web/ClientApp/src/api/auth.test.ts
+++ b/SporeSync.Web/ClientApp/src/api/auth.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, api, shouldRedirectToLogin } from "./client";
+import type { AuthSession } from "./types";
+
+const session: AuthSession = {
+  authRequired: true,
+  authenticated: true,
+  username: "admin",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("auth api client", () => {
+  it("posts credentials to the login endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(session));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await api.login("admin", "s3cret");
+
+    expect(result).toEqual(session);
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/api/auth/login");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({
+      username: "admin",
+      password: "s3cret",
+    });
+  });
+
+  it("throws an ApiError with status for failed logins", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse({ message: "Invalid username or password." }, 401),
+        ),
+    );
+
+    const error = await api.login("admin", "wrong").catch((e) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(401);
+  });
+
+  it("fetches the current session", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(session));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await api.session();
+
+    expect(result).toEqual(session);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/auth/session");
+  });
+
+  it("posts to the logout endpoint", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        authRequired: true,
+        authenticated: false,
+        username: null,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.logout();
+
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/api/auth/logout");
+    expect(init.method).toBe("POST");
+  });
+});
+
+describe("shouldRedirectToLogin", () => {
+  it("redirects for 401 responses from protected endpoints", () => {
+    expect(shouldRedirectToLogin(401, "/api/status")).toBe(true);
+    expect(shouldRedirectToLogin(401, "/api/sftp-sync-jobs")).toBe(true);
+  });
+
+  it("does not redirect for auth endpoints or other statuses", () => {
+    expect(shouldRedirectToLogin(401, "/api/auth/login")).toBe(false);
+    expect(shouldRedirectToLogin(401, "/api/auth/session")).toBe(false);
+    expect(shouldRedirectToLogin(403, "/api/status")).toBe(false);
+    expect(shouldRedirectToLogin(500, "/api/status")).toBe(false);
+  });
+});

--- a/SporeSync.Web/ClientApp/src/api/client.ts
+++ b/SporeSync.Web/ClientApp/src/api/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AuthSession,
   DeleteQueueItemFileResponse,
   DownloadQueueItem,
   PagedResponse,
@@ -19,6 +20,24 @@ export interface PageQuery {
   pageSize?: number;
 }
 
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+/**
+ * A 401 outside the auth endpoints means the session expired or was never
+ * established, so the SPA should navigate to the login page. Auth endpoints
+ * are excluded because a failed login already surfaces its own error.
+ */
+export function shouldRedirectToLogin(status: number, path: string) {
+  return status === 401 && !path.startsWith("/api/auth/");
+}
+
 export async function fetchJson<T>(
   path: string,
   init?: RequestInit,
@@ -33,8 +52,18 @@ export async function fetchJson<T>(
   });
 
   if (!response.ok) {
+    if (
+      shouldRedirectToLogin(response.status, path) &&
+      typeof window !== "undefined"
+    ) {
+      window.location.assign("/login");
+    }
+
     const message = await response.text();
-    throw new Error(message || `Request failed with ${response.status}`);
+    throw new ApiError(
+      message || `Request failed with ${response.status}`,
+      response.status,
+    );
   }
 
   return response.json() as Promise<T>;
@@ -58,6 +87,13 @@ export function toQueryString(query: PageQuery = {}) {
 }
 
 export const api = {
+  session: () => fetchJson<AuthSession>("/api/auth/session"),
+  login: (username: string, password: string) =>
+    fetchJson<AuthSession>("/api/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ username, password }),
+    }),
+  logout: () => fetchJson<AuthSession>("/api/auth/logout", { method: "POST" }),
   status: () => fetchJson<StatusResponse>("/api/status"),
   runs: (query?: PageQuery) =>
     fetchJson<PagedResponse<SporeSyncRun>>(

--- a/SporeSync.Web/ClientApp/src/api/queryKeys.ts
+++ b/SporeSync.Web/ClientApp/src/api/queryKeys.ts
@@ -1,4 +1,5 @@
 export const queryKeys = {
+  session: ["auth", "session"] as const,
   status: ["status"] as const,
   runs: (query: unknown) => ["runs", query] as const,
   run: (id: string) => ["runs", id] as const,

--- a/SporeSync.Web/ClientApp/src/api/types.ts
+++ b/SporeSync.Web/ClientApp/src/api/types.ts
@@ -96,6 +96,12 @@ export interface UpsertSftpConnectionProfile {
   isDefault: boolean;
 }
 
+export interface AuthSession {
+  authRequired: boolean;
+  authenticated: boolean;
+  username: string | null;
+}
+
 export interface StatusResponse {
   status: string;
   environment: string;

--- a/SporeSync.Web/ClientApp/src/components/AppShell.tsx
+++ b/SporeSync.Web/ClientApp/src/components/AppShell.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   Info,
   LayoutDashboard,
+  LogOut,
   Menu,
   MonitorCog,
   Moon,
@@ -66,6 +67,22 @@ export function AppShell() {
     queryFn: api.status,
     refetchInterval: 30_000,
   });
+  const sessionQuery = useQuery({
+    queryKey: queryKeys.session,
+    queryFn: api.session,
+    staleTime: 60_000,
+  });
+  const showLogout =
+    sessionQuery.data?.authRequired && sessionQuery.data?.authenticated;
+
+  const logout = async () => {
+    try {
+      await api.logout();
+    } finally {
+      // Full reload clears client caches and lands on the login page.
+      window.location.assign("/login");
+    }
+  };
 
   useEffect(() => {
     localStorage.setItem(
@@ -148,21 +165,29 @@ export function AppShell() {
               </div>
             </div>
           </div>
-          <Button
-            title="Toggle theme"
-            onClick={() =>
-              setTheme(
-                theme === "system"
-                  ? "light"
-                  : theme === "light"
-                    ? "dark"
-                    : "system",
-              )
-            }
-          >
-            {themeIcon}
-            <span className="hidden sm:inline">{theme}</span>
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              title="Toggle theme"
+              onClick={() =>
+                setTheme(
+                  theme === "system"
+                    ? "light"
+                    : theme === "light"
+                      ? "dark"
+                      : "system",
+                )
+              }
+            >
+              {themeIcon}
+              <span className="hidden sm:inline">{theme}</span>
+            </Button>
+            {showLogout && (
+              <Button title="Sign out" onClick={logout}>
+                <LogOut size={16} />
+                <span className="hidden sm:inline">Sign out</span>
+              </Button>
+            )}
+          </div>
         </header>
 
         <main className="mx-auto w-full max-w-7xl px-4 py-5">

--- a/SporeSync.Web/ClientApp/src/routes/LoginPage.test.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/LoginPage.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "../api/queryKeys";
+import type { AuthSession } from "../api/types";
+import { LoginPage } from "./LoginPage";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function renderLoginPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const rootRoute = createRootRoute();
+  const loginRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: LoginPage,
+  });
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/dashboard",
+    component: () => <div>Dashboard stub</div>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([loginRoute, dashboardRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+    context: { queryClient },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+  await screen.findByRole("button", { name: /sign in/i });
+
+  return queryClient;
+}
+
+function submitCredentials(username: string, password: string) {
+  fireEvent.change(screen.getByLabelText(/username/i), {
+    target: { value: username },
+  });
+  fireEvent.change(screen.getByLabelText(/password/i), {
+    target: { value: password },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("LoginPage", () => {
+  it("renders the credential form", async () => {
+    await renderLoginPage();
+
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign in/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("stores the session and navigates to the dashboard on success", async () => {
+    const session: AuthSession = {
+      authRequired: true,
+      authenticated: true,
+      username: "admin",
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(session)));
+
+    const queryClient = await renderLoginPage();
+    submitCredentials("admin", "s3cret");
+
+    await waitFor(() =>
+      expect(screen.getByText("Dashboard stub")).toBeInTheDocument(),
+    );
+    expect(queryClient.getQueryData(queryKeys.session)).toEqual(session);
+  });
+
+  it("shows an error message when login fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse({ message: "Invalid username or password." }, 401),
+        ),
+    );
+
+    await renderLoginPage();
+    submitCredentials("admin", "wrong");
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Invalid username or password.");
+  });
+});

--- a/SporeSync.Web/ClientApp/src/routes/LoginPage.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/LoginPage.tsx
@@ -1,0 +1,83 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2, Server } from "lucide-react";
+import { type FormEvent, useState } from "react";
+import { api } from "../api/client";
+import { queryKeys } from "../api/queryKeys";
+import { Button } from "../components/Button";
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setPending(true);
+
+    try {
+      const session = await api.login(username, password);
+      queryClient.setQueryData(queryKeys.session, session);
+      await navigate({ to: "/dashboard" });
+    } catch {
+      setError("Invalid username or password.");
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 text-foreground">
+      <div className="w-full max-w-sm rounded-lg border border-border bg-panel p-6 shadow-lg">
+        <div className="mb-6 flex items-center gap-2">
+          <Server className="text-accent" size={24} />
+          <h1 className="text-lg font-semibold tracking-wide">SporeSync</h1>
+        </div>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Sign in with the administrator account to continue.
+        </p>
+        <form className="space-y-4" onSubmit={onSubmit}>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Username</span>
+            <input
+              name="username"
+              autoComplete="username"
+              required
+              className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm outline-none focus:shadow-focus"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Password</span>
+            <input
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm outline-none focus:shadow-focus"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+          {error && (
+            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+              {error}
+            </p>
+          )}
+          <Button
+            type="submit"
+            disabled={pending}
+            className="w-full bg-accent text-accent-foreground hover:bg-accent/90"
+          >
+            {pending && <Loader2 className="animate-spin" size={16} />}
+            Sign in
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/SporeSync.Web/ClientApp/src/routes/routeTree.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/routeTree.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { api } from "../api/client";
 import { queryKeys } from "../api/queryKeys";
+import type { AuthSession } from "../api/types";
 import { AppShell } from "../components/AppShell";
 import { SectionHeader } from "../components/SectionHeader";
 import { StatusBadge } from "../components/StatusBadge";
@@ -19,17 +20,55 @@ import {
   SettingsPage,
 } from "./AdminPages";
 import { DashboardPage } from "./DashboardPage";
+import { LoginPage } from "./LoginPage";
 
 interface RouterContext {
   queryClient: QueryClient;
 }
 
-const rootRoute = createRootRouteWithContext<RouterContext>()({
+async function ensureSession(queryClient: QueryClient): Promise<AuthSession> {
+  try {
+    return await queryClient.ensureQueryData({
+      queryKey: queryKeys.session,
+      queryFn: api.session,
+      staleTime: 60_000,
+    });
+  } catch {
+    // If session discovery fails (e.g. backend briefly unreachable), render
+    // the app anyway; the server still rejects unauthenticated API calls,
+    // and those 401s route back to /login.
+    return { authRequired: false, authenticated: true, username: null };
+  }
+}
+
+const rootRoute = createRootRouteWithContext<RouterContext>()({});
+
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/login",
+  beforeLoad: async ({ context }) => {
+    const session = await ensureSession(context.queryClient);
+    if (!session.authRequired || session.authenticated) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
+  component: LoginPage,
+});
+
+const appRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: "app",
+  beforeLoad: async ({ context }) => {
+    const session = await ensureSession(context.queryClient);
+    if (session.authRequired && !session.authenticated) {
+      throw redirect({ to: "/login" });
+    }
+  },
   component: AppShell,
 });
 
 const indexRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/",
   beforeLoad: () => {
     throw redirect({ to: "/dashboard" });
@@ -37,70 +76,73 @@ const indexRoute = createRoute({
 });
 
 const dashboardRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/dashboard",
   component: DashboardPage,
 });
 
 const dashboardRunRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/dashboard/runs/$runId",
   component: DashboardPage,
 });
 
 const runsRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/runs",
   component: RunsPage,
 });
 
 const runDetailRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/runs/$runId",
   component: DashboardPage,
 });
 
 const jobsRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/jobs",
   component: JobsPage,
 });
 
 const profilesRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/profiles",
   component: ProfilesPage,
 });
 
 const settingsRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/settings",
   component: SettingsPage,
 });
 
 const logsRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/logs",
   component: LogsPage,
 });
 
 const aboutRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: "/about",
   component: AboutPage,
 });
 
 export const routeTree = rootRoute.addChildren([
-  indexRoute,
-  dashboardRoute,
-  dashboardRunRoute,
-  runsRoute,
-  runDetailRoute,
-  jobsRoute,
-  profilesRoute,
-  settingsRoute,
-  logsRoute,
-  aboutRoute,
+  loginRoute,
+  appRoute.addChildren([
+    indexRoute,
+    dashboardRoute,
+    dashboardRunRoute,
+    runsRoute,
+    runDetailRoute,
+    jobsRoute,
+    profilesRoute,
+    settingsRoute,
+    logsRoute,
+    aboutRoute,
+  ]),
 ]);
 
 function RunsPage() {

--- a/SporeSync.Web/Controllers/AuthController.cs
+++ b/SporeSync.Web/Controllers/AuthController.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using SporeSync.Web.Auth;
+using SporeSync.Web.DTO;
+
+namespace SporeSync.Web.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+[AllowAnonymous]
+public sealed class AuthController : ControllerBase
+{
+    public const string LoginRateLimitPolicy = "auth-login";
+
+    private readonly AuthOptions _options;
+    private readonly AdminCredentialValidator _credentialValidator;
+    private readonly ILogger<AuthController> _logger;
+
+    public AuthController(
+        AuthOptions options,
+        AdminCredentialValidator credentialValidator,
+        ILogger<AuthController> logger)
+    {
+        _options = options;
+        _credentialValidator = credentialValidator;
+        _logger = logger;
+    }
+
+    [HttpGet("session")]
+    public ActionResult<AuthSessionResponse> GetSession()
+    {
+        return Ok(CurrentSession());
+    }
+
+    [HttpPost("login")]
+    [EnableRateLimiting(LoginRateLimitPolicy)]
+    public async Task<ActionResult<AuthSessionResponse>> Login(LoginRequest request)
+    {
+        if (!_options.Enabled)
+        {
+            return Ok(CurrentSession());
+        }
+
+        if (!_credentialValidator.Validate(request.Username, request.Password))
+        {
+            _logger.LogWarning("Failed admin login attempt from {RemoteIp}.", HttpContext.Connection.RemoteIpAddress);
+            return Unauthorized(new { message = "Invalid username or password." });
+        }
+
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, _options.Username)],
+            CookieAuthenticationDefaults.AuthenticationScheme);
+
+        await HttpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            new ClaimsPrincipal(identity));
+
+        _logger.LogInformation("Admin user {Username} logged in.", _options.Username);
+        return Ok(new AuthSessionResponse(AuthRequired: true, Authenticated: true, Username: _options.Username));
+    }
+
+    [HttpPost("logout")]
+    public async Task<ActionResult<AuthSessionResponse>> Logout()
+    {
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        return Ok(new AuthSessionResponse(AuthRequired: _options.Enabled, Authenticated: false, Username: null));
+    }
+
+    private AuthSessionResponse CurrentSession()
+    {
+        var authenticated = User.Identity?.IsAuthenticated == true;
+        return new AuthSessionResponse(
+            AuthRequired: _options.Enabled,
+            Authenticated: !_options.Enabled || authenticated,
+            Username: authenticated ? User.Identity?.Name : null);
+    }
+}

--- a/SporeSync.Web/DTO/AuthSessionResponse.cs
+++ b/SporeSync.Web/DTO/AuthSessionResponse.cs
@@ -1,0 +1,6 @@
+namespace SporeSync.Web.DTO;
+
+public sealed record AuthSessionResponse(
+    bool AuthRequired,
+    bool Authenticated,
+    string? Username);

--- a/SporeSync.Web/DTO/LoginRequest.cs
+++ b/SporeSync.Web/DTO/LoginRequest.cs
@@ -1,0 +1,3 @@
+namespace SporeSync.Web.DTO;
+
+public sealed record LoginRequest(string Username, string Password);

--- a/SporeSync.Web/Program.cs
+++ b/SporeSync.Web/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Threading.RateLimiting;
 using FluentMigrator.Runner;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.RateLimiting;
 using Scalar.AspNetCore;
 using SporeSync.Business;
@@ -13,6 +14,7 @@ using SporeSync.Web;
 using SporeSync.Web.Auth;
 using SporeSync.Web.Controllers;
 using SporeSync.Web.Hubs;
+using SporeSync.Web.Security;
 
 if (args is ["hash-password", ..])
 {
@@ -36,6 +38,16 @@ if (args is ["hash-password", ..])
 var builder = WebApplication.CreateBuilder(args);
 
 var testcontainerDatabase = await TestcontainerDatabase.StartIfEnabledAsync(builder.Configuration);
+
+var forwardedHeaderSettings =
+    builder.Configuration.GetSection(ForwardedHeaderSettings.SectionName).Get<ForwardedHeaderSettings>()
+    ?? new ForwardedHeaderSettings();
+forwardedHeaderSettings.Validate();
+
+if (forwardedHeaderSettings.Enabled)
+{
+    builder.Services.Configure<ForwardedHeadersOptions>(forwardedHeaderSettings.Configure);
+}
 
 var authOptions = builder.Configuration.GetSection(AuthOptions.SectionName).Get<AuthOptions>() ?? new AuthOptions();
 authOptions.Validate();
@@ -111,6 +123,11 @@ if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi("/openapi/{documentName}.json");
     app.MapScalarApiReference(options => options.WithTitle("SporeSync API"));
+}
+
+if (forwardedHeaderSettings.Enabled)
+{
+    app.UseForwardedHeaders();
 }
 
 app.UseHttpsRedirection();

--- a/SporeSync.Web/Program.cs
+++ b/SporeSync.Web/Program.cs
@@ -1,5 +1,8 @@
 using System.Text.Json;
+using System.Threading.RateLimiting;
 using FluentMigrator.Runner;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.RateLimiting;
 using Scalar.AspNetCore;
 using SporeSync.Business;
 using SporeSync.Business.Interface;
@@ -7,11 +10,75 @@ using SporeSync.Domain.Interface;
 using SporeSync.Infrastructure;
 using SporeSync.Infrastructure.Logging;
 using SporeSync.Web;
+using SporeSync.Web.Auth;
+using SporeSync.Web.Controllers;
 using SporeSync.Web.Hubs;
+
+if (args is ["hash-password", ..])
+{
+    var password = args.Length > 1 ? args[1] : null;
+    if (password is null)
+    {
+        Console.Write("Password: ");
+        password = Console.ReadLine();
+    }
+
+    if (string.IsNullOrEmpty(password))
+    {
+        Console.Error.WriteLine("A non-empty password is required.");
+        return 1;
+    }
+
+    Console.WriteLine(PasswordHasher.Hash(password));
+    return 0;
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
 var testcontainerDatabase = await TestcontainerDatabase.StartIfEnabledAsync(builder.Configuration);
+
+var authOptions = builder.Configuration.GetSection(AuthOptions.SectionName).Get<AuthOptions>() ?? new AuthOptions();
+authOptions.Validate();
+builder.Services.AddSingleton(authOptions);
+builder.Services.AddSingleton<AdminCredentialValidator>();
+
+builder.Services
+    .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(options =>
+    {
+        options.Cookie.Name = ".SporeSync.Auth";
+        options.Cookie.HttpOnly = true;
+        options.Cookie.SameSite = SameSiteMode.Lax;
+        options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+        options.ExpireTimeSpan = TimeSpan.FromHours(authOptions.SessionHours);
+        options.SlidingExpiration = true;
+
+        // The SPA handles login navigation, so the API and hub endpoints
+        // return status codes instead of redirecting to a login page.
+        options.Events.OnRedirectToLogin = context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return Task.CompletedTask;
+        };
+        options.Events.OnRedirectToAccessDenied = context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return Task.CompletedTask;
+        };
+    });
+builder.Services.AddAuthorization();
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.AddPolicy(AuthController.LoginRateLimitPolicy, context =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1)
+            }));
+});
 
 builder.Services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
 builder.Services.AddEndpointsApiExplorer();
@@ -50,8 +117,22 @@ app.UseHttpsRedirection();
 app.UseDefaultFiles();
 app.UseStaticFiles();
 
-app.MapControllers();
-app.MapHub<DashboardHub>("/hubs/dashboard");
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseRateLimiter();
+
+var controllers = app.MapControllers();
+var dashboardHub = app.MapHub<DashboardHub>("/hubs/dashboard");
+
+if (authOptions.Enabled)
+{
+    // AuthController opts out with [AllowAnonymous] so login and session
+    // discovery keep working. Static SPA assets stay anonymous; the SPA
+    // itself redirects to /login based on /api/auth/session.
+    controllers.RequireAuthorization();
+    dashboardHub.RequireAuthorization();
+}
+
 app.MapFallbackToFile("index.html");
 
 try
@@ -65,3 +146,5 @@ finally
         await testcontainerDatabase.DisposeAsync();
     }
 }
+
+return 0;

--- a/SporeSync.Web/Security/ForwardedHeaderSettings.cs
+++ b/SporeSync.Web/Security/ForwardedHeaderSettings.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders;
+
+namespace SporeSync.Web.Security;
+
+public sealed class ForwardedHeaderSettings
+{
+    public const string SectionName = "ForwardedHeaders";
+
+    public bool Enabled { get; set; }
+    public string[] KnownProxies { get; set; } = [];
+    public string[] KnownNetworks { get; set; } = [];
+    public int ForwardLimit { get; set; } = 1;
+
+    public void Validate()
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        if (ForwardLimit < 1)
+        {
+            throw new InvalidOperationException("ForwardedHeaders:ForwardLimit must be at least 1.");
+        }
+
+        if (KnownProxies.Length == 0 && KnownNetworks.Length == 0)
+        {
+            throw new InvalidOperationException(
+                "ForwardedHeaders is enabled, but no trusted proxy or network is configured. " +
+                "Set ForwardedHeaders:KnownProxies or ForwardedHeaders:KnownNetworks explicitly.");
+        }
+
+        _ = KnownProxies.Select(ParseIpAddress).ToArray();
+        _ = KnownNetworks.Select(ParseNetwork).ToArray();
+    }
+
+    public void Configure(ForwardedHeadersOptions options)
+    {
+        Validate();
+
+        if (!Enabled)
+        {
+            return;
+        }
+
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+        options.ForwardLimit = ForwardLimit;
+        options.RequireHeaderSymmetry = true;
+
+        options.KnownProxies.Clear();
+        foreach (var proxy in KnownProxies.Select(ParseIpAddress))
+        {
+            options.KnownProxies.Add(proxy);
+        }
+
+        options.KnownIPNetworks.Clear();
+        foreach (var network in KnownNetworks.Select(ParseNetwork))
+        {
+            options.KnownIPNetworks.Add(network);
+        }
+    }
+
+    private static IPAddress ParseIpAddress(string value)
+    {
+        if (IPAddress.TryParse(value, out var address))
+        {
+            return address;
+        }
+
+        throw new InvalidOperationException($"ForwardedHeaders contains an invalid IP address: '{value}'.");
+    }
+
+    private static IPNetwork ParseNetwork(string value)
+    {
+        var parts = value.Split('/', StringSplitOptions.TrimEntries);
+        if (parts.Length != 2 || !IPAddress.TryParse(parts[0], out var prefix) || !int.TryParse(parts[1], out var prefixLength))
+        {
+            throw new InvalidOperationException(
+                $"ForwardedHeaders contains an invalid CIDR network: '{value}'. Use CIDR notation such as '172.18.0.0/16'.");
+        }
+
+        var maxPrefixLength = prefix.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork ? 32 : 128;
+        if (prefixLength < 0 || prefixLength > maxPrefixLength)
+        {
+            throw new InvalidOperationException(
+                $"ForwardedHeaders contains an invalid CIDR prefix length for '{value}'.");
+        }
+
+        return new IPNetwork(prefix, prefixLength);
+    }
+}

--- a/SporeSync.Web/appsettings.Development.json
+++ b/SporeSync.Web/appsettings.Development.json
@@ -2,6 +2,9 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=SporeSync;Username=sporesync;Password=sporesync"
   },
+  "Auth": {
+    "Enabled": false
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/SporeSync.Web/appsettings.json
+++ b/SporeSync.Web/appsettings.json
@@ -2,6 +2,13 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=SporeSync;Username=sporesync;Password=sporesync"
   },
+  "Auth": {
+    "Enabled": true,
+    "Username": "admin",
+    "Password": "",
+    "PasswordHash": "",
+    "SessionHours": 12
+  },
   "SporeSync": {
     "SchedulerIntervalSeconds": 10,
     "DownloadPollIntervalMs": 1000,

--- a/SporeSync.Web/appsettings.json
+++ b/SporeSync.Web/appsettings.json
@@ -9,6 +9,12 @@
     "PasswordHash": "",
     "SessionHours": 12
   },
+  "ForwardedHeaders": {
+    "Enabled": false,
+    "KnownProxies": [],
+    "KnownNetworks": [],
+    "ForwardLimit": 1
+  },
   "SporeSync": {
     "SchedulerIntervalSeconds": 10,
     "DownloadPollIntervalMs": 1000,

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -79,6 +79,9 @@ shell history.
 
 The cookie is issued with `HttpOnly`, `SameSite=Lax`, and `Secure` when the
 request arrives over HTTPS. Terminate TLS in front of the app in production.
+When TLS terminates at a reverse proxy, configure trusted forwarded headers as
+described in [`docker-compose-deployment.md`](docker-compose-deployment.md) so
+the app sees the original HTTPS scheme.
 
 ## Local development
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,121 @@
+# Authentication
+
+SporeSync protects its API, dashboard SPA, and SignalR hub with a minimal
+single-admin login. There is one configurable administrator account, cookie
+sessions, and no user database or role system.
+
+## What is protected
+
+When authentication is enabled:
+
+- All API controllers require an authenticated session and return `401` when
+  it is missing or expired. Exceptions: `/api/auth/login`, `/api/auth/logout`,
+  and `/api/auth/session` remain anonymous so the SPA can sign in and discover
+  session state.
+- The SignalR hub at `/hubs/dashboard` requires an authenticated session; the
+  negotiation request is rejected with `401` otherwise.
+- Static SPA assets (`index.html`, JS, CSS) stay anonymous so the login page
+  can load. The SPA redirects unauthenticated visitors to `/login` based on
+  `/api/auth/session`, and the server independently rejects all data access.
+
+Login attempts are rate limited to 10 per minute per source IP address.
+
+## Configuration
+
+Settings live in the `Auth` section (`SporeSync.Web/appsettings.json`), or as
+environment variables using the `Auth__` prefix:
+
+```json
+{
+  "Auth": {
+    "Enabled": true,
+    "Username": "admin",
+    "Password": "",
+    "PasswordHash": "",
+    "SessionHours": 12
+  }
+}
+```
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `Auth:Enabled` | `true` (production), `false` (Development) | Requires login for API, SPA data, and SignalR access. |
+| `Auth:Username` | `admin` | The single admin username. |
+| `Auth:PasswordHash` | empty | PBKDF2-SHA256 hash of the admin password. Preferred credential source; takes precedence over `Auth:Password`. |
+| `Auth:Password` | empty | Plaintext admin password. Intended for local development only. |
+| `Auth:SessionHours` | `12` | Sliding lifetime of the session cookie, in hours. |
+
+When `Auth:Enabled` is `true`, the application refuses to start until
+`Auth:PasswordHash` or `Auth:Password` is set. This makes deployments secure
+by default: an unconfigured production instance fails fast with a clear error
+message instead of serving data anonymously.
+
+### Generating a password hash
+
+```bash
+dotnet run --project SporeSync.Web/SporeSync.Web.csproj -- hash-password
+```
+
+The command prompts for a password and prints a value like
+`PBKDF2-SHA256.210000.<salt>.<hash>` for `Auth:PasswordHash` (environment
+variable `Auth__PasswordHash`). You can also pass the password as an argument
+(`-- hash-password 'my-password'`), but the interactive prompt keeps it out of
+shell history.
+
+## Login and session flow
+
+1. The SPA calls `GET /api/auth/session` on navigation. The response reports
+   `{ authRequired, authenticated, username }`.
+2. If authentication is required and there is no session, the SPA redirects to
+   `/login` and posts credentials to `POST /api/auth/login`.
+3. On success, the server issues an HTTP-only, same-site session cookie
+   (`.SporeSync.Auth`) with a sliding expiration of `Auth:SessionHours`.
+   Because SignalR uses the same cookie, the dashboard hub connection works
+   without extra configuration.
+4. `POST /api/auth/logout` clears the session. The "Sign out" button in the
+   header appears whenever authentication is enabled.
+5. If a session expires, API calls return `401` and the SPA returns to the
+   login page.
+
+The cookie is issued with `HttpOnly`, `SameSite=Lax`, and `Secure` when the
+request arrives over HTTPS. Terminate TLS in front of the app in production.
+
+## Local development
+
+`appsettings.Development.json` ships with `Auth:Enabled: false`, so the usual
+`dotnet run` / Vite workflow needs no login. To exercise the login flow
+locally, enable it with a plaintext dev password:
+
+```json
+{
+  "Auth": {
+    "Enabled": true,
+    "Username": "admin",
+    "Password": "dev-password"
+  }
+}
+```
+
+or via user secrets / environment variables:
+
+```bash
+Auth__Enabled=true Auth__Password=dev-password \
+  dotnet run --project SporeSync.Web/SporeSync.Web.csproj
+```
+
+The Vite dev server proxies `/api` and `/hubs` to the backend, so cookie login
+works the same at `http://localhost:5173`.
+
+## Docker Compose deployment
+
+Add the credential to the `web` service environment (see
+[`docker-compose-deployment.md`](docker-compose-deployment.md)):
+
+```yaml
+environment:
+  Auth__Username: admin
+  Auth__PasswordHash: "PBKDF2-SHA256.210000.<salt>.<hash>"
+```
+
+Quote the hash so YAML does not misinterpret the dots. To run without
+authentication on a trusted network, set `Auth__Enabled: "false"` explicitly.

--- a/docs/docker-compose-deployment.md
+++ b/docs/docker-compose-deployment.md
@@ -49,6 +49,8 @@ services:
     environment:
       ASPNETCORE_URLS: http://+:8080
       ConnectionStrings__DefaultConnection: Host=postgres;Port=5432;Database=SporeSync;Username=sporesync;Password=change-this-database-password
+      Auth__Username: admin
+      Auth__PasswordHash: "change-this-to-a-generated-password-hash"
       Security__EncryptionKeyPath: /var/lib/sporesync/secrets/encryption.key
       SporeSync__DestinationRootPath: /downloads
       SporeSync__SchedulerIntervalSeconds: 10
@@ -83,6 +85,12 @@ volumes:
 Change both database password values to the same strong password before starting
 the stack. If you built the image locally, replace the `web.image` value with
 `sporesync-web:local`.
+
+Set `Auth__PasswordHash` to a hash generated with
+`dotnet run --project SporeSync.Web/SporeSync.Web.csproj -- hash-password`;
+the container refuses to start without an admin credential. See
+[`authentication.md`](authentication.md) for the full authentication
+configuration, including how to disable login on a trusted network.
 
 ## Start the stack
 

--- a/docs/docker-compose-deployment.md
+++ b/docs/docker-compose-deployment.md
@@ -140,3 +140,49 @@ Database migrations run automatically during web startup.
   Docker host and container network can resolve and reach those hosts.
 - When running behind a reverse proxy, terminate TLS at the proxy and forward
   traffic to the web container on port `8080`.
+
+## TLS reverse proxy headers
+
+If a production reverse proxy terminates TLS and forwards HTTP to the web
+container, enable forwarded headers so SporeSync sees the original HTTPS scheme
+and client IP address. This is required for `Secure` auth cookies, login rate
+limiting, and audit logs to behave as if the request reached the app directly
+over HTTPS.
+
+Do not enable forwarded headers without also configuring the trusted proxy IP
+or network. The app rejects that configuration at startup because otherwise a
+client could spoof `X-Forwarded-For` or `X-Forwarded-Proto`.
+
+Example for a reverse proxy on an explicit Docker network:
+
+```yaml
+services:
+  web:
+    environment:
+      ForwardedHeaders__Enabled: "true"
+      ForwardedHeaders__KnownNetworks__0: "172.30.80.0/24"
+      ForwardedHeaders__ForwardLimit: "1"
+    networks:
+      - sporesync-edge
+      - default
+
+networks:
+  sporesync-edge:
+    ipam:
+      config:
+        - subnet: 172.30.80.0/24
+```
+
+Use `ForwardedHeaders__KnownProxies__0` instead of `KnownNetworks` when the
+reverse proxy has a stable single IP address, for example:
+
+```yaml
+environment:
+  ForwardedHeaders__Enabled: "true"
+  ForwardedHeaders__KnownProxies__0: "172.30.80.10"
+  ForwardedHeaders__ForwardLimit: "1"
+```
+
+Configure the proxy to send `X-Forwarded-For` and `X-Forwarded-Proto`. Trust
+only the Docker subnet or proxy address that can connect directly to the web
+container.


### PR DESCRIPTION
## Summary

- Adds minimal single-admin, cookie-based authentication protecting all API controllers and the `/hubs/dashboard` SignalR hub via `RequireAuthorization()`, with `/api/auth/login|logout|session` remaining anonymous for the SPA.
- New `Auth` configuration section (`Enabled`, `Username`, `Password`, `PasswordHash`, `SessionHours`). Credentials are verified with PBKDF2-SHA256 and fixed-time comparison; a `hash-password` CLI subcommand (`dotnet run --project SporeSync.Web -- hash-password`) generates the hash. Login is rate limited to 10 attempts/minute/IP.
- Secure by default: with auth enabled and no credential configured, startup fails fast with a clear error. `appsettings.Development.json` ships with `Auth:Enabled: false` so the local dev workflow is unchanged.
- SPA: new `/login` page, router-level session guard (redirects to `/login` when unauthenticated, away from `/login` when signed in), sign-out button in the header, and automatic redirect to `/login` on 401 responses.
- No multi-user RBAC: one configurable admin account, no user database, matching the app's single-operator architecture.

## Docs

- New `docs/authentication.md` covering configuration, hash generation, the login/session flow, protected endpoints, local development, and Docker Compose.
- README authentication section and updated `docs/docker-compose-deployment.md` with `Auth__*` environment variables.

## Tests

- Backend: `PasswordHasherTests`, `AdminCredentialValidatorTests`, `AuthOptionsTests`, `AuthControllerTests` (36 new tests; full suite 106 passed including Testcontainers integration tests).
- Frontend: `auth.test.ts` (API client + 401 redirect rule) and `LoginPage.test.tsx` (form render, successful login navigation, failure message); 14 tests passed, `biome:check` and `tsc -b` clean, production build succeeds.
- Manual smoke test with auth enabled: anonymous API/hub requests return 401, login sets the cookie, authed API/hub return 200, logout revokes access, rate limiter returns 429, missing credential aborts startup.

## Follow-up concerns

- Existing deployments must set `Auth__PasswordHash` (or `Auth__Enabled=false`) before upgrading, or the container will refuse to start.
- Sessions use the default ASP.NET Core Data Protection key ring; in multi-container or ephemeral-storage deployments, cookies are invalidated on restart unless keys are persisted.
- SignalR reconnects that fail after cookie expiry only show the "disconnected" indicator; the user is routed to login on their next navigation or API call.

Made with [Cursor](https://cursor.com)