### PR TITLE
Make restart recovery safe across instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Worker settings in `appsettings.json`:
     "DownloadPollIntervalMs": 1000,
     "SftpConnectionTimeoutSeconds": 30,
     "SftpOperationTimeoutSeconds": 300,
+    "DownloadLeaseSeconds": 300,
+    "RunScanLeaseSeconds": 1800,
+    "RecoverySweepIntervalSeconds": 60,
     "DownloadMaxRetries": 3,
     "DownloadRetryBaseDelaySeconds": 30,
     "DownloadRetryMaxDelaySeconds": 900,
@@ -142,6 +145,16 @@ Worker settings in `appsettings.json`:
   }
 }
 ```
+
+SporeSync recovers interrupted work with renewable PostgreSQL leases. A recovery
+sweep runs at startup before this instance begins scheduling or downloading, and
+then every `RecoverySweepIntervalSeconds`. Expired scanning runs are marked
+failed so the job can run again; expired downloading items are reset and
+requeued on their existing run. Sweeps always honor unexpired leases, including
+at startup, so multiple instances cannot steal live work from one another. A
+crashed instance's work is therefore recovered after its last lease expires
+(bounded by `RunScanLeaseSeconds` or `DownloadLeaseSeconds`) and the next sweep.
+Recovery changes are logged and broadcast to connected dashboards.
 
 Failed downloads are retried within the same sync run. `DownloadMaxRetries` is
 the number of retries after the initial attempt. Retry delays use bounded

--- a/SporeSync.Business.Tests/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/DownloadWorkerHostedServiceTests.cs
@@ -397,7 +397,6 @@ public sealed class DownloadWorkerHostedServiceTests : IDisposable
             => Task.FromResult(_items.GetValueOrDefault(id));
 
         public Task<IReadOnlyList<DownloadQueueItem>> RequeueStaleAsync(
-            bool ignoreLeases,
             CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
@@ -558,7 +557,6 @@ public sealed class DownloadWorkerHostedServiceTests : IDisposable
             => throw new NotSupportedException();
 
         public Task<IReadOnlyList<SporeSyncRun>> ReapOrphanedAsync(
-            bool ignoreLeases,
             CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 

--- a/SporeSync.Business.Tests/ReliabilityIntegrationTests.cs
+++ b/SporeSync.Business.Tests/ReliabilityIntegrationTests.cs
@@ -310,6 +310,46 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
     }
 
     [Fact]
+    public async Task ReclaimedGroup_CannotClaimOrRenewAnotherWorkersLiveLeaf()
+    {
+        var job = await CreateJobAsync();
+        var run = await CreateRunAsync(job.Id, status: "downloading");
+        var items = await _queueRepository.UpsertManyAsync(
+        [
+            NewUpsert(job.Id, run.Id, "/incoming/show", isGroup: true, childCount: 1),
+            NewUpsert(job.Id, run.Id, "/incoming/show/episode.mkv", groupRemotePath: "/incoming/show")
+        ]);
+        var group = Assert.Single(items, item => item.IsGroup);
+        var leaf = Assert.Single(items, item => !item.IsGroup);
+
+        // Worker A claims both the parent and the child before it stops
+        // renewing only the parent lease.
+        var claimedGroupByWorkerA = await ClaimForJobAsync(job.Id);
+        Assert.Equal(group.Id, claimedGroupByWorkerA!.Id);
+        var claimedLeafByWorkerA = await _queueRepository.ClaimGroupLeafAsync(
+            leaf.Id,
+            run.Id,
+            group.RemotePath,
+            LeaseSeconds);
+        Assert.NotNull(claimedLeafByWorkerA);
+
+        // Recovery may reclaim the expired parent while the child's lease is
+        // still live on Worker A.
+        await BackdateItemLeaseAsync(group.Id);
+        var requeued = await _queueRepository.RequeueStaleAsync();
+        Assert.Contains(requeued, item => item.Id == group.Id);
+        var claimedGroupByWorkerB = await ClaimForJobAsync(job.Id);
+        Assert.Equal(group.Id, claimedGroupByWorkerB!.Id);
+
+        Assert.True(await _queueRepository.RenewLeaseAsync(leaf.Id, LeaseSeconds));
+        Assert.Null(await _queueRepository.ClaimGroupLeafAsync(
+            leaf.Id,
+            run.Id,
+            group.RemotePath,
+            LeaseSeconds));
+    }
+
+    [Fact]
     public async Task RecoverySweep_HonorsLeases_RecoversInterruptedWork_AndIsIdempotent()
     {
         var job = await CreateJobAsync();

--- a/SporeSync.Business.Tests/ReliabilityIntegrationTests.cs
+++ b/SporeSync.Business.Tests/ReliabilityIntegrationTests.cs
@@ -110,32 +110,18 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
         Assert.NotNull(claimed);
 
         // Lease is still valid: the periodic sweep must not touch the item.
-        var untouched = await _queueRepository.RequeueStaleAsync(ignoreLeases: false);
+        var untouched = await _queueRepository.RequeueStaleAsync();
         Assert.DoesNotContain(untouched, requeued => requeued.Id == item.Id);
 
         await BackdateItemLeaseAsync(item.Id);
 
-        var requeued = await _queueRepository.RequeueStaleAsync(ignoreLeases: false);
+        var requeued = await _queueRepository.RequeueStaleAsync();
         var recovered = Assert.Single(requeued, r => r.Id == item.Id);
         Assert.Equal("queued", recovered.Status);
         Assert.Equal(claimed!.RetryCount + 1, recovered.RetryCount);
         Assert.Equal(0, recovered.BytesDownloaded);
         Assert.Null(recovered.ErrorMessage);
         Assert.Null(recovered.StartedAt);
-    }
-
-    [Fact]
-    public async Task RequeueStale_IgnoringLeases_RequeuesActiveClaims()
-    {
-        var job = await CreateJobAsync();
-        var run = await CreateRunAsync(job.Id, status: "downloading");
-        var item = await UpsertItemAsync(job.Id, run.Id, "/incoming/startup.bin");
-
-        Assert.NotNull(await ClaimForJobAsync(job.Id));
-
-        var requeued = await _queueRepository.RequeueStaleAsync(ignoreLeases: true);
-        var recovered = Assert.Single(requeued, r => r.Id == item.Id);
-        Assert.Equal("queued", recovered.Status);
     }
 
     [Fact]
@@ -172,7 +158,7 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
         Assert.True(await _queueRepository.RenewLeaseAsync(item.Id, LeaseSeconds));
 
         // The renewed lease protects the item from the periodic sweep.
-        var requeued = await _queueRepository.RequeueStaleAsync(ignoreLeases: false);
+        var requeued = await _queueRepository.RequeueStaleAsync();
         Assert.DoesNotContain(requeued, r => r.Id == item.Id);
     }
 
@@ -189,12 +175,12 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
         });
 
         // Lease still valid: run must survive the periodic sweep.
-        var untouched = await _runRepository.ReapOrphanedAsync(ignoreLeases: false);
+        var untouched = await _runRepository.ReapOrphanedAsync();
         Assert.DoesNotContain(untouched, reaped => reaped.Id == run.Id);
 
         await BackdateRunLeaseAsync(run.Id);
 
-        var reapedRuns = await _runRepository.ReapOrphanedAsync(ignoreLeases: false);
+        var reapedRuns = await _runRepository.ReapOrphanedAsync();
         var reaped = Assert.Single(reapedRuns, r => r.Id == run.Id);
         Assert.Equal("failed", reaped.Status);
         Assert.NotNull(reaped.ErrorMessage);
@@ -222,7 +208,7 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
             Options.Create(new SporeSyncOptions()),
             NullLogger<QueueRecoveryHostedService>.Instance);
 
-        await service.SweepAsync(ignoreLeases: false, CancellationToken.None);
+        await service.SweepAsync(CancellationToken.None);
 
         var persisted = await _runRepository.GetByIdAsync(run.Id);
         Assert.Equal("scanning", persisted!.Status);
@@ -256,7 +242,7 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
             BytesDownloaded = 100
         });
 
-        var reapedRuns = await _runRepository.ReapOrphanedAsync(ignoreLeases: false);
+        var reapedRuns = await _runRepository.ReapOrphanedAsync();
         var reaped = Assert.Single(reapedRuns, r => r.Id == run.Id);
         Assert.Equal("completed", reaped.Status);
         Assert.Equal(1, reaped.CompletedFileCount);
@@ -324,7 +310,7 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
     }
 
     [Fact]
-    public async Task RecoverySweep_RequeuesStaleItems_AndReapsOrphanedRuns()
+    public async Task RecoverySweep_HonorsLeases_RecoversInterruptedWork_AndIsIdempotent()
     {
         var job = await CreateJobAsync();
         var run = await CreateRunAsync(job.Id, status: "downloading");
@@ -336,13 +322,44 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
         var orphanedScanJob = await CreateJobAsync();
         var orphanedScanRun = await CreateRunAsync(orphanedScanJob.Id, status: "scanning");
 
-        // Simulate a process crash: startup sweep runs with ignoreLeases: true.
+        var terminalJob = await CreateJobAsync();
+        var terminalRun = await CreateRunAsync(terminalJob.Id, status: "downloading");
+        var terminalItem = await UpsertItemAsync(terminalJob.Id, terminalRun.Id, "/incoming/done.bin");
+        Assert.NotNull(await ClaimForJobAsync(terminalJob.Id));
+        terminalItem = await _queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+        {
+            Id = terminalItem.Id,
+            Status = "completed",
+            BytesDownloaded = terminalItem.FileSizeBytes
+        });
+        terminalRun = await _runRepository.UpdateStatusAsync(new UpdateSporeSyncRunStatus
+        {
+            Id = terminalRun.Id,
+            Status = "completed"
+        });
+
+        var notifier = new RecordingNotifier();
         var service = new QueueRecoveryHostedService(
-            BuildScopeFactory(),
+            BuildScopeFactory(notifier),
             Options.Create(new SporeSyncOptions()),
             NullLogger<QueueRecoveryHostedService>.Instance);
 
-        await service.SweepAsync(ignoreLeases: true, CancellationToken.None);
+        // A concurrent instance may still own both leases, so startup recovery
+        // must leave them alone until their renewable leases expire.
+        await service.SweepAsync(CancellationToken.None);
+        Assert.Equal("downloading", (await _queueRepository.GetByIdAsync(item.Id))!.Status);
+        Assert.Equal("scanning", (await _runRepository.GetByIdAsync(orphanedScanRun.Id))!.Status);
+        Assert.DoesNotContain(notifier.QueueItems, updated => updated.Id == item.Id);
+        Assert.DoesNotContain(notifier.Runs, updated => updated.Id == orphanedScanRun.Id);
+        Assert.Equal("completed", (await _queueRepository.GetByIdAsync(terminalItem.Id))!.Status);
+        Assert.Equal("completed", (await _runRepository.GetByIdAsync(terminalRun.Id))!.Status);
+        Assert.DoesNotContain(notifier.QueueItems, updated => updated.Id == terminalItem.Id);
+        Assert.DoesNotContain(notifier.Runs, updated => updated.Id == terminalRun.Id);
+
+        // Simulate the former owners disappearing without renewing their leases.
+        await BackdateItemLeaseAsync(item.Id);
+        await BackdateRunLeaseAsync(orphanedScanRun.Id);
+        await service.SweepAsync(CancellationToken.None);
 
         var recoveredItem = await _queueRepository.GetByIdAsync(item.Id);
         Assert.Equal("queued", recoveredItem!.Status);
@@ -350,6 +367,17 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
 
         var reapedRun = await _runRepository.GetByIdAsync(orphanedScanRun.Id);
         Assert.Equal("failed", reapedRun!.Status);
+        Assert.Contains(notifier.QueueItems, updated => updated.Id == item.Id && updated.Status == "queued");
+        Assert.Contains(notifier.Runs, updated => updated.Id == orphanedScanRun.Id && updated.Status == "failed");
+
+        var queueNotificationCount = notifier.QueueItems.Count;
+        var runNotificationCount = notifier.Runs.Count;
+        await service.SweepAsync(CancellationToken.None);
+        var afterSecondSweep = await _queueRepository.GetByIdAsync(item.Id);
+        Assert.Equal("queued", afterSecondSweep!.Status);
+        Assert.Equal(recoveredItem.RetryCount, afterSecondSweep.RetryCount);
+        Assert.Equal(queueNotificationCount, notifier.QueueItems.Count);
+        Assert.Equal(runNotificationCount, notifier.Runs.Count);
 
         // The interrupted download run keeps its requeued item and stays claimable.
         var downloadRun = await _runRepository.GetByIdAsync(run.Id);
@@ -359,12 +387,12 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
         Assert.Equal(item.Id, reclaimed!.Id);
     }
 
-    private IServiceScopeFactory BuildScopeFactory()
+    private IServiceScopeFactory BuildScopeFactory(ISyncDashboardNotifier? notifier = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton<IDownloadQueueItemRepository>(_queueRepository);
         services.AddSingleton<ISporeSyncRunRepository>(_runRepository);
-        services.AddSingleton<ISyncDashboardNotifier, NoopNotifier>();
+        services.AddSingleton(notifier ?? new NoopNotifier());
 
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
@@ -376,6 +404,26 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
 
         public Task NotifyQueueItemUpdatedAsync(DownloadQueueItem item, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
+    }
+
+    private sealed class RecordingNotifier : ISyncDashboardNotifier
+    {
+        public List<SporeSyncRun> Runs { get; } = [];
+        public List<DownloadQueueItem> QueueItems { get; } = [];
+
+        public Task NotifyRunUpdatedAsync(SporeSyncRun run, CancellationToken cancellationToken = default)
+        {
+            Runs.Add(run);
+            return Task.CompletedTask;
+        }
+
+        public Task NotifyQueueItemUpdatedAsync(
+            DownloadQueueItem item,
+            CancellationToken cancellationToken = default)
+        {
+            QueueItems.Add(item);
+            return Task.CompletedTask;
+        }
     }
 
     private async Task<SporeSyncJob> CreateJobAsync()

--- a/SporeSync.Business.Tests/SporeSyncJobServiceTests.cs
+++ b/SporeSync.Business.Tests/SporeSyncJobServiceTests.cs
@@ -268,7 +268,6 @@ public sealed class SporeSyncJobServiceTests
             => throw new NotSupportedException();
 
         public Task<IReadOnlyList<SporeSyncRun>> ReapOrphanedAsync(
-            bool ignoreLeases,
             CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 

--- a/SporeSync.Business.Tests/SyncRunControlServiceTests.cs
+++ b/SporeSync.Business.Tests/SyncRunControlServiceTests.cs
@@ -195,7 +195,6 @@ public sealed class SyncRunControlServiceTests
             => throw new NotSupportedException();
 
         public Task<IReadOnlyList<SporeSyncRun>> ReapOrphanedAsync(
-            bool ignoreLeases,
             CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
     }

--- a/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
@@ -395,7 +395,6 @@ public sealed class DownloadWorkerHostedServiceTests
             => Task.FromResult<DownloadQueueItem?>(null);
 
         public Task<IReadOnlyList<DownloadQueueItem>> RequeueStaleAsync(
-            bool ignoreLeases,
             CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
@@ -624,7 +623,6 @@ public sealed class DownloadWorkerHostedServiceTests
             => Task.FromResult(true);
 
         public Task<IReadOnlyList<SporeSyncRun>> ReapOrphanedAsync(
-            bool ignoreLeases,
             CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 

--- a/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
@@ -255,6 +255,35 @@ public sealed class DownloadWorkerHostedServiceTests
     }
 
     [Fact]
+    public async Task ProcessNextItem_GroupLeafDownload_RenewsLeafLeaseBeforeRecoverySweep()
+    {
+        var group = CreateItem("/remote/reports/", isGroup: true, childCount: 1);
+        var leaf = CreateItem("/remote/reports/large.bin", groupRemotePath: group.RemotePath, status: "queued");
+        var queueRepository = new FakeQueueRepository(group)
+        {
+            Leaves = [leaf]
+        };
+        var downloader = new BlockingDownloader();
+        var worker = CreateWorker(queueRepository, downloader, downloadLeaseSeconds: 1);
+        var recovery = new QueueRecoveryHostedService(
+            BuildRecoveryScopeFactory(queueRepository),
+            Options.Create(new SporeSyncOptions()),
+            NullLogger<QueueRecoveryHostedService>.Instance);
+
+        var processing = worker.ProcessNextItemAsync(CancellationToken.None);
+        await downloader.WaitUntilStartedAsync();
+
+        // The sweep occurs after the original one-second leaf lease expired.
+        await Task.Delay(TimeSpan.FromMilliseconds(1500));
+        await recovery.SweepAsync(CancellationToken.None);
+
+        Assert.DoesNotContain(leaf.Id, queueRepository.RequeuedIds);
+
+        downloader.Complete(SftpDownloadResult.Succeed(100, 50));
+        Assert.True(await processing);
+    }
+
+    [Fact]
     public async Task ProcessNextItem_GroupConnectFailure_MarksLeavesFailedAndRecordsGroupFailure()
     {
         var group = CreateItem("/remote/reports/", isGroup: true, fileSizeBytes: 300, childCount: 2);
@@ -283,10 +312,11 @@ public sealed class DownloadWorkerHostedServiceTests
 
     private static DownloadWorkerHostedService CreateWorker(
         FakeQueueRepository queueRepository,
-        FakeDownloader downloader,
+        ISftpFileDownloader downloader,
         int maxRetries = 3,
         int baseDelaySeconds = 30,
         int stabilityWindowSeconds = 15,
+        int downloadLeaseSeconds = 300,
         CountingSftpClientFactory? clientFactory = null)
     {
         var options = Options.Create(new SporeSyncOptions
@@ -295,7 +325,8 @@ public sealed class DownloadWorkerHostedServiceTests
             DownloadMaxRetries = maxRetries,
             DownloadRetryBaseDelaySeconds = baseDelaySeconds,
             DownloadRetryJitterRatio = 0,
-            RemoteFileStabilityWindowSeconds = stabilityWindowSeconds
+            RemoteFileStabilityWindowSeconds = stabilityWindowSeconds,
+            DownloadLeaseSeconds = downloadLeaseSeconds
         });
 
         var services = new ServiceCollection();
@@ -313,6 +344,15 @@ public sealed class DownloadWorkerHostedServiceTests
             new SporeSyncMetrics(),
             new DownloadRetryPolicy(options),
             NullLogger<DownloadWorkerHostedService>.Instance);
+    }
+
+    private static IServiceScopeFactory BuildRecoveryScopeFactory(FakeQueueRepository queueRepository)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IDownloadQueueItemRepository>(queueRepository);
+        services.AddSingleton<ISporeSyncRunRepository>(new FakeRunRepository());
+        services.AddSingleton<ISyncDashboardNotifier>(new FakeNotifier());
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
 
     private static DownloadQueueItem CreateItem(
@@ -351,6 +391,7 @@ public sealed class DownloadWorkerHostedServiceTests
     private sealed class FakeQueueRepository : IDownloadQueueItemRepository
     {
         private DownloadQueueItem? _claimable;
+        private readonly Dictionary<Guid, DateTimeOffset> _leaseExpiresAt = [];
 
         public FakeQueueRepository(DownloadQueueItem claimable)
         {
@@ -365,10 +406,17 @@ public sealed class DownloadWorkerHostedServiceTests
 
         public List<DeferCall> DeferCalls { get; } = [];
 
+        public List<Guid> RequeuedIds { get; } = [];
+
         public Task<DownloadQueueItem?> ClaimNextAsync(int leaseSeconds, CancellationToken cancellationToken = default)
         {
             var item = _claimable;
             _claimable = null;
+            if (item is not null)
+            {
+                _leaseExpiresAt[item.Id] = DateTimeOffset.UtcNow.AddSeconds(leaseSeconds);
+            }
+
             return Task.FromResult(item);
         }
 
@@ -385,18 +433,51 @@ public sealed class DownloadWorkerHostedServiceTests
                 && leaf.GroupRemotePath == groupRemotePath
                 && string.Equals(leaf.Status, "queued", StringComparison.OrdinalIgnoreCase));
 
+            if (leaf is not null)
+            {
+                _leaseExpiresAt[leaf.Id] = DateTimeOffset.UtcNow.AddSeconds(leaseSeconds);
+            }
+
             return Task.FromResult(leaf);
         }
 
         public Task<bool> RenewLeaseAsync(Guid id, int leaseSeconds, CancellationToken cancellationToken = default)
-            => Task.FromResult(true);
+        {
+            if (!_leaseExpiresAt.ContainsKey(id))
+            {
+                return Task.FromResult(false);
+            }
+
+            _leaseExpiresAt[id] = DateTimeOffset.UtcNow.AddSeconds(leaseSeconds);
+            return Task.FromResult(true);
+        }
 
         public Task<DownloadQueueItem?> ReleaseAsync(Guid id, CancellationToken cancellationToken = default)
             => Task.FromResult<DownloadQueueItem?>(null);
 
         public Task<IReadOnlyList<DownloadQueueItem>> RequeueStaleAsync(
             CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+        {
+            var staleIds = _leaseExpiresAt
+                .Where(entry => entry.Value <= DateTimeOffset.UtcNow)
+                .Select(entry => entry.Key)
+                .ToArray();
+            var requeued = new List<DownloadQueueItem>();
+
+            foreach (var id in staleIds)
+            {
+                var leaf = Leaves.FirstOrDefault(item => item.Id == id);
+                if (leaf is not null)
+                {
+                    RequeuedIds.Add(id);
+                    requeued.Add(leaf);
+                }
+
+                _leaseExpiresAt.Remove(id);
+            }
+
+            return Task.FromResult<IReadOnlyList<DownloadQueueItem>>(requeued);
+        }
 
         public Task<IReadOnlyList<DownloadQueueItem>> GetLeavesForGroupAsync(
             Guid runId,
@@ -532,6 +613,42 @@ public sealed class DownloadWorkerHostedServiceTests
         }
     }
 
+    private sealed class BlockingDownloader : ISftpFileDownloader
+    {
+        private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<SftpDownloadResult> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WaitUntilStartedAsync() => _started.Task;
+
+        public void Complete(SftpDownloadResult result) => _completion.TrySetResult(result);
+
+        public Task<SftpDownloadResult> DownloadAsync(
+            Guid connectionProfileId,
+            string remotePath,
+            string localPath,
+            CancellationToken cancellationToken = default)
+            => DownloadAsync(connectionProfileId, remotePath, localPath, progress: null, cancellationToken);
+
+        public Task<SftpDownloadResult> DownloadAsync(
+            Guid connectionProfileId,
+            string remotePath,
+            string localPath,
+            IProgress<long>? progress,
+            CancellationToken cancellationToken = default)
+        {
+            _started.TrySetResult();
+            return _completion.Task;
+        }
+
+        public Task<SftpDownloadResult> DownloadAsync(
+            IConnectedSftpClient connection,
+            string remotePath,
+            string localPath,
+            IProgress<long>? progress = null,
+            CancellationToken cancellationToken = default)
+            => DownloadAsync(ProfileId, remotePath, localPath, progress, cancellationToken);
+    }
+
     private sealed class CountingSftpClientFactory : ISftpClientFactory
     {
         public int ConnectCalls { get; private set; }
@@ -624,7 +741,7 @@ public sealed class DownloadWorkerHostedServiceTests
 
         public Task<IReadOnlyList<SporeSyncRun>> ReapOrphanedAsync(
             CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+            => Task.FromResult<IReadOnlyList<SporeSyncRun>>([]);
 
         public Task<int> RetryFailedItemsAsync(Guid runId, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();

--- a/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
@@ -284,6 +284,32 @@ public sealed class DownloadWorkerHostedServiceTests
     }
 
     [Fact]
+    public async Task ProcessNextItem_ReclaimedGroup_LeavesAnotherWorkersLiveLeafAlone()
+    {
+        // Worker A still owns this child. Worker B reclaimed only the parent
+        // after its lease expired, so it must not renew, download, or complete
+        // the child on Worker A's behalf.
+        var reclaimedGroup = CreateItem("/remote/reports/", isGroup: true, childCount: 1);
+        var liveLeafOwnedByWorkerA = CreateItem(
+            "/remote/reports/large.bin",
+            groupRemotePath: reclaimedGroup.RemotePath,
+            status: "downloading");
+        var queueRepository = new FakeQueueRepository(reclaimedGroup)
+        {
+            Leaves = [liveLeafOwnedByWorkerA]
+        };
+        var downloader = new FakeDownloader(_ => SftpDownloadResult.Succeed(100, 50));
+        var workerB = CreateWorker(queueRepository, downloader);
+
+        var processed = await workerB.ProcessNextItemAsync(CancellationToken.None);
+
+        Assert.True(processed);
+        Assert.Empty(downloader.RequestedPaths);
+        Assert.DoesNotContain(queueRepository.ProgressUpdates, update => update.Id == liveLeafOwnedByWorkerA.Id);
+        Assert.Equal([reclaimedGroup.Id], queueRepository.ReleasedIds);
+    }
+
+    [Fact]
     public async Task ProcessNextItem_GroupConnectFailure_MarksLeavesFailedAndRecordsGroupFailure()
     {
         var group = CreateItem("/remote/reports/", isGroup: true, fileSizeBytes: 300, childCount: 2);
@@ -360,7 +386,7 @@ public sealed class DownloadWorkerHostedServiceTests
         bool isGroup = false,
         int childCount = 0,
         string? groupRemotePath = null,
-        string status = "downloading",
+        string status = "queued",
         long bytesDownloaded = 0,
         int retryCount = 0,
         long fileSizeBytes = 100)
@@ -408,6 +434,8 @@ public sealed class DownloadWorkerHostedServiceTests
 
         public List<Guid> RequeuedIds { get; } = [];
 
+        public List<Guid> ReleasedIds { get; } = [];
+
         public Task<DownloadQueueItem?> ClaimNextAsync(int leaseSeconds, CancellationToken cancellationToken = default)
         {
             var item = _claimable;
@@ -431,7 +459,8 @@ public sealed class DownloadWorkerHostedServiceTests
                 leaf.Id == id
                 && leaf.SyncRunId == runId
                 && leaf.GroupRemotePath == groupRemotePath
-                && string.Equals(leaf.Status, "queued", StringComparison.OrdinalIgnoreCase));
+                && (string.Equals(leaf.Status, "queued", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(leaf.Status, "failed", StringComparison.OrdinalIgnoreCase)));
 
             if (leaf is not null)
             {
@@ -453,7 +482,10 @@ public sealed class DownloadWorkerHostedServiceTests
         }
 
         public Task<DownloadQueueItem?> ReleaseAsync(Guid id, CancellationToken cancellationToken = default)
-            => Task.FromResult<DownloadQueueItem?>(null);
+        {
+            ReleasedIds.Add(id);
+            return Task.FromResult<DownloadQueueItem?>(CreateResult(id, "queued", 0));
+        }
 
         public Task<IReadOnlyList<DownloadQueueItem>> RequeueStaleAsync(
             CancellationToken cancellationToken = default)

--- a/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
+++ b/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
@@ -327,8 +327,20 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                     continue;
                 }
 
+                // A reclaimed group may observe a child which is still actively
+                // leased by another worker. This worker owns only the group, not
+                // that child, so it must not renew, download, or terminal-update
+                // it. Release the reclaimed group for a later pass instead of
+                // falsely completing the group around the active child.
+                if (string.Equals(currentLeaf.Status, "downloading", StringComparison.OrdinalIgnoreCase))
+                {
+                    return await queueRepository.ReleaseAsync(groupItem.Id, cancellationToken)
+                        ?? throw new InvalidOperationException(
+                            $"Group queue item '{groupItem.Id}' was no longer claimed while deferring to its active child.");
+                }
+
                 if (!string.Equals(currentLeaf.Status, "queued", StringComparison.OrdinalIgnoreCase)
-                    && !string.Equals(currentLeaf.Status, "downloading", StringComparison.OrdinalIgnoreCase))
+                    && !string.Equals(currentLeaf.Status, "failed", StringComparison.OrdinalIgnoreCase))
                 {
                     if (!string.Equals(currentLeaf.Status, "failed", StringComparison.OrdinalIgnoreCase))
                     {
@@ -337,7 +349,8 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                     }
                 }
 
-                if (string.Equals(currentLeaf.Status, "queued", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(currentLeaf.Status, "queued", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(currentLeaf.Status, "failed", StringComparison.OrdinalIgnoreCase))
                 {
                     var claimedLeaf = await queueRepository.ClaimGroupLeafAsync(
                         currentLeaf.Id,

--- a/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
+++ b/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
@@ -392,6 +392,11 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                 }, cancellationToken);
 
                 SftpDownloadResult leafResult;
+                using var leafRenewalCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var leafLeaseRenewalTask = RenewLeaseWhileProcessingAsync(
+                    queueRepository,
+                    currentLeaf.Id,
+                    leafRenewalCts.Token);
                 try
                 {
                     if (connection is not null && !connection.IsConnected)
@@ -416,6 +421,11 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                         currentLeaf.RemotePath,
                         job.Id);
                     leafResult = SftpDownloadResult.Failure(ex.Message);
+                }
+                finally
+                {
+                    leafRenewalCts.Cancel();
+                    await leafLeaseRenewalTask;
                 }
 
                 RecordDownloadResult(job.Id, currentLeaf.RemotePath, leafResult);

--- a/SporeSync.Business/Worker/QueueRecoveryHostedService.cs
+++ b/SporeSync.Business/Worker/QueueRecoveryHostedService.cs
@@ -12,9 +12,10 @@ namespace SporeSync.Business.Worker;
 /// * requeues claimed queue items whose lease expired (crashed/hung worker);
 /// * reaps orphaned runs (queued/scanning runs with an expired lease are failed,
 ///   downloading runs with no pending items are finalized as completed).
-/// Runs once at startup — before the scheduler and download worker start, and
-/// ignoring leases since no in-process work can be in flight yet — and then
-/// periodically while the host is running.
+/// Runs once at startup — before this instance's scheduler and download worker
+/// start — and then periodically while the host is running. Every sweep honors
+/// leases because another application instance may still own the work. A crashed
+/// process's work is therefore recovered once its last renewable lease expires.
 /// </summary>
 public sealed class QueueRecoveryHostedService : BackgroundService
 {
@@ -38,7 +39,7 @@ public sealed class QueueRecoveryHostedService : BackgroundService
         // claiming work (hosted services start sequentially in registration order).
         try
         {
-            await SweepAsync(ignoreLeases: true, cancellationToken);
+            await SweepAsync(cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -65,7 +66,7 @@ public sealed class QueueRecoveryHostedService : BackgroundService
 
             try
             {
-                await SweepAsync(ignoreLeases: false, stoppingToken);
+                await SweepAsync(stoppingToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -74,14 +75,14 @@ public sealed class QueueRecoveryHostedService : BackgroundService
         }
     }
 
-    public async Task SweepAsync(bool ignoreLeases, CancellationToken cancellationToken)
+    public async Task SweepAsync(CancellationToken cancellationToken)
     {
         using var scope = _scopeFactory.CreateScope();
         var queueRepository = scope.ServiceProvider.GetRequiredService<IDownloadQueueItemRepository>();
         var runRepository = scope.ServiceProvider.GetRequiredService<ISporeSyncRunRepository>();
         var notifier = scope.ServiceProvider.GetRequiredService<ISyncDashboardNotifier>();
 
-        var requeuedItems = await queueRepository.RequeueStaleAsync(ignoreLeases, cancellationToken);
+        var requeuedItems = await queueRepository.RequeueStaleAsync(cancellationToken);
         if (requeuedItems.Count > 0)
         {
             _logger.LogWarning(
@@ -105,7 +106,7 @@ public sealed class QueueRecoveryHostedService : BackgroundService
             }
         }
 
-        var reapedRuns = await runRepository.ReapOrphanedAsync(ignoreLeases, cancellationToken);
+        var reapedRuns = await runRepository.ReapOrphanedAsync(cancellationToken);
         if (reapedRuns.Count > 0)
         {
             _logger.LogWarning(

--- a/SporeSync.Domain/Interface/IDownloadQueueItemRepository.cs
+++ b/SporeSync.Domain/Interface/IDownloadQueueItemRepository.cs
@@ -73,11 +73,10 @@ public interface IDownloadQueueItemRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Requeues claimed items whose lease expired (or all claimed items when
-    /// <paramref name="ignoreLeases"/> is true, e.g. at startup).
+    /// Atomically requeues claimed items whose lease expired. Unexpired leases
+    /// are always preserved so concurrent application instances cannot steal work.
     /// </summary>
     Task<IReadOnlyList<DownloadQueueItem>> RequeueStaleAsync(
-        bool ignoreLeases,
         CancellationToken cancellationToken = default);
 
     Task<DownloadQueueItem> UpdateProgressAsync(

--- a/SporeSync.Domain/Interface/IDownloadQueueItemRepository.cs
+++ b/SporeSync.Domain/Interface/IDownloadQueueItemRepository.cs
@@ -45,8 +45,8 @@ public interface IDownloadQueueItemRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Claims a queued internal group leaf only while its run is still downloading.
-    /// Returns <c>null</c> when the run was cancelled or the leaf is no longer queued.
+    /// Claims a queued or failed internal group leaf only while its run is still downloading.
+    /// Returns <c>null</c> when the run was cancelled or the leaf is not claimable.
     /// </summary>
     Task<DownloadQueueItem?> ClaimGroupLeafAsync(
         Guid id,

--- a/SporeSync.Domain/Interface/ISporeSyncRunRepository.cs
+++ b/SporeSync.Domain/Interface/ISporeSyncRunRepository.cs
@@ -47,12 +47,11 @@ public interface ISporeSyncRunRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Reaps orphaned runs: queued/scanning runs whose lease expired are marked
-    /// failed, and downloading runs with no pending items are finalized as
-    /// completed. Returns every run that was mutated.
+    /// Atomically reaps orphaned runs: queued/scanning runs whose lease expired
+    /// are marked failed, and downloading runs with no pending items are finalized
+    /// as completed. Unexpired leases are preserved. Returns every mutated run.
     /// </summary>
     Task<IReadOnlyList<SporeSyncRun>> ReapOrphanedAsync(
-        bool ignoreLeases,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/SporeSync.Infrastructure/Repository/DownloadQueueItemRepository.cs
+++ b/SporeSync.Infrastructure/Repository/DownloadQueueItemRepository.cs
@@ -579,7 +579,6 @@ public sealed class DownloadQueueItemRepository : IDownloadQueueItemRepository
     }
 
     public async Task<IReadOnlyList<DownloadQueueItem>> RequeueStaleAsync(
-        bool ignoreLeases,
         CancellationToken cancellationToken = default)
     {
         const string sql = """
@@ -608,7 +607,9 @@ public sealed class DownloadQueueItemRepository : IDownloadQueueItemRepository
 
         await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
         await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("ignore_lease", ignoreLeases);
+        // Recovery must never bypass leases: another application instance may
+        // still be renewing and processing the item.
+        command.Parameters.AddWithValue("ignore_lease", false);
 
         return await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpRequeueStaleItems,
             async reader =>

--- a/SporeSync.Infrastructure/Repository/DownloadQueueItemRepository.cs
+++ b/SporeSync.Infrastructure/Repository/DownloadQueueItemRepository.cs
@@ -471,7 +471,7 @@ public sealed class DownloadQueueItemRepository : IDownloadQueueItemRepository
                   AND qi.sync_run_id = @run_id
                   AND qi.group_remote_path = @group_remote_path
                   AND qi.is_group = false
-                  AND qi.status = 'queued'
+                  AND qi.status IN ('queued', 'failed')
                   AND EXISTS (
                       SELECT 1
                       FROM core.sftp_sync_runs r

--- a/SporeSync.Infrastructure/Repository/SporeSyncRunRepository.cs
+++ b/SporeSync.Infrastructure/Repository/SporeSyncRunRepository.cs
@@ -353,7 +353,6 @@ public sealed class SporeSyncRunRepository : ISporeSyncRunRepository
     }
 
     public async Task<IReadOnlyList<SporeSyncRun>> ReapOrphanedAsync(
-        bool ignoreLeases,
         CancellationToken cancellationToken = default)
     {
         const string sql = """
@@ -376,7 +375,9 @@ public sealed class SporeSyncRunRepository : ISporeSyncRunRepository
 
         await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
         await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("ignore_lease", ignoreLeases);
+        // Recovery must never bypass leases: another application instance may
+        // still be renewing and scanning the run.
+        command.Parameters.AddWithValue("ignore_lease", false);
 
         return await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpReapOrphanedRuns,
             async reader =>


### PR DESCRIPTION
Closes #16

## Summary
- make startup and periodic recovery always honor renewable PostgreSQL leases, preventing one application instance from stealing live scan or download work from another
- retain the existing recovery policy: expired scanning runs fail, expired downloading items are safely requeued, and completed records remain untouched
- keep recovery logging and dashboard broadcasts, and document the lease-expiry recovery window and relevant settings
- extend PostgreSQL integration coverage for active leases, interrupted scans/downloads, terminal records, idempotent repeat sweeps, resumed claims, and dashboard notifications

## Validation
- `dotnet build SporeSync.sln --no-restore` — passed (5 existing package warnings)
- `dotnet test SporeSync.Business.Tests/SporeSync.Business.Tests.csproj --filter FullyQualifiedName~ReliabilityIntegrationTests` — passed (13/13)
- `dotnet test SporeSync.sln --no-build` — passed (257/257)
- Frontend checks not run: no UI files changed.