### PR TITLE
Make sync-run creation explicitly atomic

### DIFF
--- a/SporeSync.Business.Tests/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/DownloadWorkerHostedServiceTests.cs
@@ -542,7 +542,7 @@ public sealed class DownloadWorkerHostedServiceTests : IDisposable
         public Task<PagedResult<SporeSyncRun>> GetRunsAsync(RunQuery query, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
-        public Task<SporeSyncRun?> CreateAsync(
+        public Task<SporeSyncRun?> TryCreateAsync(
             Guid jobId,
             int leaseSeconds = 1800,
             CancellationToken cancellationToken = default)

--- a/SporeSync.Business.Tests/ReliabilityIntegrationTests.cs
+++ b/SporeSync.Business.Tests/ReliabilityIntegrationTests.cs
@@ -65,23 +65,37 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
     }
 
     [Fact]
-    public async Task CreateRun_IsAtomic_SecondCreateReturnsNull()
+    public async Task TryCreateRun_ConcurrentAttemptsCreateExactlyOneActiveRun()
     {
         var job = await CreateJobAsync();
 
-        var first = await _runRepository.CreateAsync(job.Id, LeaseSeconds);
-        Assert.NotNull(first);
+        var attempts = Enumerable.Range(0, 20)
+            .Select(_ => new SporeSyncRunRepository(_fixture.DataSource)
+                .TryCreateAsync(job.Id, LeaseSeconds));
+        var results = await Task.WhenAll(attempts);
 
-        var second = await _runRepository.CreateAsync(job.Id, LeaseSeconds);
-        Assert.Null(second);
+        var first = Assert.Single(results, run => run is not null)!;
+        Assert.Equal(19, results.Count(run => run is null));
+
+        await using var connection = await _fixture.DataSource.OpenConnectionAsync();
+        await using var countCommand = new NpgsqlCommand("""
+            SELECT count(*)
+            FROM core.sftp_sync_runs
+            WHERE job_id = @job_id
+              AND status IN ('queued', 'scanning', 'downloading');
+            """, connection);
+        countCommand.Parameters.AddWithValue("job_id", job.Id);
+        var activeRunCount = (long)(await countCommand.ExecuteScalarAsync()
+            ?? throw new InvalidOperationException("Active run count query returned no value."));
+        Assert.Equal(1L, activeRunCount);
 
         await _runRepository.UpdateStatusAsync(new UpdateSporeSyncRunStatus
         {
-            Id = first!.Id,
+            Id = first.Id,
             Status = "completed"
         });
 
-        var third = await _runRepository.CreateAsync(job.Id, LeaseSeconds);
+        var third = await _runRepository.TryCreateAsync(job.Id, LeaseSeconds);
         Assert.NotNull(third);
     }
 
@@ -390,7 +404,7 @@ public sealed class ReliabilityIntegrationTests : IClassFixture<RepositoryTestco
 
     private async Task<SporeSyncRun> CreateRunAsync(Guid jobId, string? status = null)
     {
-        var run = await _runRepository.CreateAsync(jobId, LeaseSeconds);
+        var run = await _runRepository.TryCreateAsync(jobId, LeaseSeconds);
         Assert.NotNull(run);
 
         if (status is not null)

--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -253,7 +253,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
 
         var group = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
         {
@@ -461,7 +461,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
         });
 
         Assert.False(await runRepository.HasActiveRunAsync(job.Id));
-        var run = await runRepository.CreateAsync(job.Id, leaseSeconds: 300);
+        var run = await runRepository.TryCreateAsync(job.Id, leaseSeconds: 300);
         Assert.NotNull(run);
         Assert.Equal("queued", run!.Status);
         Assert.True(await runRepository.HasActiveRunAsync(job.Id));
@@ -516,7 +516,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
         var groupRemotePath = "/incoming/reports/";
 
         var group = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
@@ -587,7 +587,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
         var item = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
         {
             JobId = job.Id,
@@ -634,7 +634,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id, leaseSeconds: 300);
+        var run = await runRepository.TryCreateAsync(job.Id, leaseSeconds: 300);
         Assert.NotNull(run);
 
         var item = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
@@ -781,7 +781,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
 
         var upsert = new UpsertDownloadQueueItem
         {
@@ -834,7 +834,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
         var groupRemotePath = "/incoming/reports/";
 
         var group = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
@@ -903,7 +903,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var firstRun = await runRepository.CreateAsync(job.Id);
+        var firstRun = await runRepository.TryCreateAsync(job.Id);
         var groupRemotePath = "/incoming/reports/";
 
         UpsertDownloadQueueItem CreateLeafUpsert(Guid runId, bool preserve) => new()
@@ -933,7 +933,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
             Id = firstRun.Id,
             Status = "completed"
         });
-        var secondRun = await runRepository.CreateAsync(job.Id);
+        var secondRun = await runRepository.TryCreateAsync(job.Id);
 
         var carried = await queueRepository.UpsertAsync(CreateLeafUpsert(secondRun.Id, preserve: true));
 
@@ -966,7 +966,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
 
         var upsert = new UpsertDownloadQueueItem
         {
@@ -1011,7 +1011,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
 
         await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
         {
@@ -1060,7 +1060,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
         var item = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
         {
             JobId = job.Id,
@@ -1099,7 +1099,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
         await runRepository.UpdateStatusAsync(new UpdateSporeSyncRunStatus
         {
             Id = run.Id,
@@ -1179,7 +1179,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
 
         var scanning = await runRepository.AdvanceScanStatusAsync(new UpdateSporeSyncRunStatus
         {
@@ -1212,7 +1212,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
 
         await runRepository.AdvanceScanStatusAsync(new UpdateSporeSyncRunStatus
         {
@@ -1272,7 +1272,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
         await SeedQueueItemAsync(job.Id, run.Id, "/incoming/pending.csv", "queued", 100, 0);
 
         var cancelled = await runRepository.CancelAsync(run.Id);
@@ -1304,7 +1304,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
         run = await runRepository.UpdateStatusAsync(new UpdateSporeSyncRunStatus
         {
             Id = run.Id,

--- a/SporeSync.Business.Tests/RetentionPruningIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RetentionPruningIntegrationTests.cs
@@ -24,7 +24,7 @@ public sealed class RetentionPruningIntegrationTests : IClassFixture<RepositoryT
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
 
-        var oldRun = await runRepository.CreateAsync(job.Id);
+        var oldRun = await runRepository.TryCreateAsync(job.Id);
         var completedItem = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
         {
             JobId = job.Id,
@@ -49,7 +49,7 @@ public sealed class RetentionPruningIntegrationTests : IClassFixture<RepositoryT
         });
         await BackdateRunAsync(oldRun.Id, DateTimeOffset.UtcNow.AddDays(-90));
 
-        var recentRun = await runRepository.CreateAsync(job.Id);
+        var recentRun = await runRepository.TryCreateAsync(job.Id);
 
         var result = await runRepository.PruneHistoryAsync(DateTimeOffset.UtcNow.AddDays(-30));
 
@@ -76,7 +76,7 @@ public sealed class RetentionPruningIntegrationTests : IClassFixture<RepositoryT
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
 
         var item = await queueRepository.UpsertAsync(new UpsertDownloadQueueItem
         {
@@ -120,7 +120,7 @@ public sealed class RetentionPruningIntegrationTests : IClassFixture<RepositoryT
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var activeRun = await runRepository.CreateAsync(job.Id);
+        var activeRun = await runRepository.TryCreateAsync(job.Id);
         await runRepository.UpdateStatusAsync(new UpdateSporeSyncRunStatus
         {
             Id = activeRun.Id,

--- a/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
@@ -94,7 +94,7 @@ public sealed class SftpSyncEndToEndTests :
 
         var job = await CreateJobAsync(scope.ServiceProvider, caseRoot, "full-pipeline");
 
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
         run = await orchestrator.ScanAsync(job, run);
 
         Assert.Equal("downloading", run.Status);
@@ -127,7 +127,7 @@ public sealed class SftpSyncEndToEndTests :
 
         // Re-scan with no remote changes: nothing is enqueued and the run
         // completes immediately.
-        var secondRun = await runRepository.CreateAsync(job.Id);
+        var secondRun = await runRepository.TryCreateAsync(job.Id);
         secondRun = await orchestrator.ScanAsync(job, secondRun);
         Assert.Equal("completed", secondRun.Status);
         Assert.Equal(0, secondRun.TotalFileCount);
@@ -145,7 +145,7 @@ public sealed class SftpSyncEndToEndTests :
 
         var job = await CreateJobAsync(scope.ServiceProvider, caseRoot, "modified-file");
 
-        var firstRun = await orchestrator.ScanAsync(job, await runRepository.CreateAsync(job.Id));
+        var firstRun = await orchestrator.ScanAsync(job, await runRepository.TryCreateAsync(job.Id));
         Assert.Equal("downloading", firstRun.Status);
         await DrainDownloadQueueAsync();
 
@@ -154,7 +154,7 @@ public sealed class SftpSyncEndToEndTests :
 
         await _sftp.WriteFileAsync($"{caseRoot}/report.csv", "version-2-with-more-content");
 
-        var secondRun = await orchestrator.ScanAsync(job, await runRepository.CreateAsync(job.Id));
+        var secondRun = await orchestrator.ScanAsync(job, await runRepository.TryCreateAsync(job.Id));
         Assert.Equal("downloading", secondRun.Status);
         Assert.Equal(1, secondRun.TotalFileCount);
         await DrainDownloadQueueAsync();
@@ -179,13 +179,13 @@ public sealed class SftpSyncEndToEndTests :
 
         var job = await CreateJobAsync(scope.ServiceProvider, caseRoot, "remote-delete");
 
-        var firstRun = await orchestrator.ScanAsync(job, await runRepository.CreateAsync(job.Id));
+        var firstRun = await orchestrator.ScanAsync(job, await runRepository.TryCreateAsync(job.Id));
         Assert.Equal("downloading", firstRun.Status);
         await DrainDownloadQueueAsync();
 
         await _sftp.DeleteFileAsync($"{caseRoot}/gone.txt");
 
-        var secondRun = await orchestrator.ScanAsync(job, await runRepository.CreateAsync(job.Id));
+        var secondRun = await orchestrator.ScanAsync(job, await runRepository.TryCreateAsync(job.Id));
         Assert.Equal("completed", secondRun.Status);
         Assert.Equal(1, secondRun.SkippedFileCount);
 

--- a/SporeSync.Business.Tests/SporeSyncJobServiceTests.cs
+++ b/SporeSync.Business.Tests/SporeSyncJobServiceTests.cs
@@ -232,7 +232,7 @@ public sealed class SporeSyncJobServiceTests
         public Task<SporeSyncRun?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
-        public Task<SporeSyncRun?> CreateAsync(
+        public Task<SporeSyncRun?> TryCreateAsync(
             Guid jobId,
             int leaseSeconds = 1800,
             CancellationToken cancellationToken = default)

--- a/SporeSync.Business.Tests/SyncRunControlServiceTests.cs
+++ b/SporeSync.Business.Tests/SyncRunControlServiceTests.cs
@@ -173,7 +173,7 @@ public sealed class SyncRunControlServiceTests
         public Task<PagedResult<SporeSyncRun>> GetRunsAsync(RunQuery query, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
-        public Task<SporeSyncRun?> CreateAsync(
+        public Task<SporeSyncRun?> TryCreateAsync(
             Guid jobId,
             int leaseSeconds = 1800,
             CancellationToken cancellationToken = default)

--- a/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
@@ -551,7 +551,7 @@ public sealed class DownloadWorkerHostedServiceTests
         public Task<SporeSyncRun?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => Task.FromResult<SporeSyncRun?>(CreateRun(id, "downloading"));
 
-        public Task<SporeSyncRun?> CreateAsync(
+        public Task<SporeSyncRun?> TryCreateAsync(
             Guid jobId,
             int leaseSeconds = 1800,
             CancellationToken cancellationToken = default)

--- a/SporeSync.Business/Service/SyncJobRunService.cs
+++ b/SporeSync.Business/Service/SyncJobRunService.cs
@@ -44,7 +44,7 @@ public sealed class SyncJobRunService : ISyncJobRunService
 
         // Creation is atomic: null means another caller (scheduler or a concurrent
         // manual trigger) created an active run first.
-        var run = await _runRepository.CreateAsync(jobId, _options.RunScanLeaseSeconds, cancellationToken);
+        var run = await _runRepository.TryCreateAsync(jobId, _options.RunScanLeaseSeconds, cancellationToken);
         if (run is null)
         {
             return new SyncJobRunResult { Error = SyncJobRunError.ActiveRunExists };

--- a/SporeSync.Business/Worker/JobSchedulerHostedService.cs
+++ b/SporeSync.Business/Worker/JobSchedulerHostedService.cs
@@ -81,16 +81,11 @@ public sealed class JobSchedulerHostedService : BackgroundService
         Interface.ISyncDashboardNotifier notifier,
         CancellationToken cancellationToken)
     {
-        if (await runRepository.HasActiveRunAsync(job.Id, cancellationToken))
-        {
-            return;
-        }
-
         await jobRepository.MarkPolledAsync(job.Id, cancellationToken);
 
         // Creation is atomic: it returns null when another scheduler tick or a
         // manual trigger created an active run for this job in the meantime.
-        var run = await runRepository.CreateAsync(job.Id, _options.RunScanLeaseSeconds, cancellationToken);
+        var run = await runRepository.TryCreateAsync(job.Id, _options.RunScanLeaseSeconds, cancellationToken);
         if (run is null)
         {
             return;

--- a/SporeSync.Domain/Interface/ISporeSyncRunRepository.cs
+++ b/SporeSync.Domain/Interface/ISporeSyncRunRepository.cs
@@ -16,7 +16,7 @@ public interface ISporeSyncRunRepository
     /// Atomically creates a run for the job, or returns <c>null</c> when the job
     /// already has an active (queued/scanning/downloading) run.
     /// </summary>
-    Task<SporeSyncRun?> CreateAsync(
+    Task<SporeSyncRun?> TryCreateAsync(
         Guid jobId,
         int leaseSeconds = 1800,
         CancellationToken cancellationToken = default);

--- a/SporeSync.Infrastructure/Repository/SporeSyncRunRepository.cs
+++ b/SporeSync.Infrastructure/Repository/SporeSyncRunRepository.cs
@@ -13,7 +13,7 @@ public sealed class SporeSyncRunRepository : ISporeSyncRunRepository
     private const string OpCountRuns = "CountRuns";
     private const string OpGetRuns = "GetRuns";
     private const string OpGetRunById = "GetRunById";
-    private const string OpCreateRun = "CreateRun";
+    private const string OpTryCreateRun = "TryCreateRun";
     private const string OpUpdateRunStatus = "UpdateRunStatus";
     private const string OpJobHasActiveRun = "JobHasActiveRun";
     private const string OpRecalculateAggregates = "RecalculateAggregates";
@@ -152,7 +152,7 @@ public sealed class SporeSyncRunRepository : ISporeSyncRunRepository
             }, cancellationToken);
     }
 
-    public async Task<SporeSyncRun?> CreateAsync(
+    public async Task<SporeSyncRun?> TryCreateAsync(
         Guid jobId,
         int leaseSeconds = 1800,
         CancellationToken cancellationToken = default)
@@ -180,7 +180,7 @@ public sealed class SporeSyncRunRepository : ISporeSyncRunRepository
         command.Parameters.AddWithValue("job_id", jobId);
         command.Parameters.AddWithValue("lease_seconds", leaseSeconds);
 
-        return await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpCreateRun,
+        return await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpTryCreateRun,
             async reader =>
             {
                 if (!await reader.ReadAsync(cancellationToken))


### PR DESCRIPTION
Closes #17

## Summary
- expose the run repository operation as `TryCreateAsync` so its atomic conflict semantics are explicit
- route scheduler and manual triggers through the same PostgreSQL-backed try-create path
- remove the scheduler check-then-create preflight while retaining the poll timestamp update before the attempt
- prove 20 concurrent PostgreSQL attempts create exactly one active run and return no-op results to the other callers

## Validation
- `dotnet build SporeSync.sln` — passed (0 errors; existing warnings remain)
- `dotnet test SporeSync.sln` — passed (258/258)
- `dotnet test SporeSync.Business.Tests/SporeSync.Business.Tests.csproj --filter "FullyQualifiedName~ReliabilityIntegrationTests.TryCreateRun_ConcurrentAttemptsCreateExactlyOneActiveRun" --logger "console;verbosity=normal"` — passed (1/1)