### PR TITLE
Queue manual scans in a managed background worker

### DIFF
--- a/SporeSync.Business.Tests/SporeSyncJobsControllerRunTests.cs
+++ b/SporeSync.Business.Tests/SporeSyncJobsControllerRunTests.cs
@@ -4,11 +4,32 @@ using SporeSync.Business.Interface;
 using SporeSync.Domain.Model;
 using SporeSync.Web;
 using SporeSync.Web.Controllers;
+using SporeSync.Web.DTO;
 
 namespace SporeSync.Business.Tests;
 
 public sealed class SporeSyncJobsControllerRunTests
 {
+    [Fact]
+    public async Task RunNow_ReturnsAcceptedWithQueuedRun()
+    {
+        var run = new SporeSyncRun
+        {
+            Id = Guid.NewGuid(), JobId = Guid.NewGuid(), JobName = "manual", Status = "queued",
+            StartedAt = DateTimeOffset.UtcNow, TotalFileCount = 0, CompletedFileCount = 0,
+            SkippedFileCount = 0, FailedFileCount = 0, TotalBytes = 0, DownloadedBytes = 0
+        };
+        var controller = new SporeSyncJobsController(
+            new FakeSporeSyncJobService(),
+            new FakeSyncJobRunService { Result = new SyncJobRunResult { Run = run } });
+
+        var result = await controller.RunNow(run.JobId, CancellationToken.None);
+
+        var accepted = Assert.IsType<AcceptedResult>(result.Result);
+        var response = Assert.IsType<SporeSyncRunResponse>(accepted.Value);
+        Assert.Equal(run.Id, response.Id);
+    }
+
     [Fact]
     public async Task RunNow_ReturnsConflict_WhenActiveRunExists()
     {
@@ -24,6 +45,22 @@ public sealed class SporeSyncJobsControllerRunTests
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
         Assert.Equal(StatusCodes.Status409Conflict, problem.Status);
+    }
+
+    [Fact]
+    public async Task RunNow_ReturnsTooManyRequests_WhenManualQueueIsFull()
+    {
+        var controller = new SporeSyncJobsController(
+            new FakeSporeSyncJobService(),
+            new FakeSyncJobRunService
+            {
+                Result = new SyncJobRunResult { Error = SyncJobRunError.QueueSaturated }
+            });
+
+        var result = await controller.RunNow(Guid.NewGuid(), CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status429TooManyRequests, objectResult.StatusCode);
     }
 
     [Fact]

--- a/SporeSync.Business.Tests/SporeSyncJobsControllerRunTests.cs
+++ b/SporeSync.Business.Tests/SporeSyncJobsControllerRunTests.cs
@@ -13,21 +13,14 @@ public sealed class SporeSyncJobsControllerRunTests
     [Fact]
     public async Task RunNow_ReturnsAcceptedWithQueuedRun()
     {
-        var run = new SporeSyncRun
-        {
-            Id = Guid.NewGuid(), JobId = Guid.NewGuid(), JobName = "manual", Status = "queued",
-            StartedAt = DateTimeOffset.UtcNow, TotalFileCount = 0, CompletedFileCount = 0,
-            SkippedFileCount = 0, FailedFileCount = 0, TotalBytes = 0, DownloadedBytes = 0
-        };
-        var controller = new SporeSyncJobsController(
-            new FakeSporeSyncJobService(),
+        var run = new SporeSyncRun { Id = Guid.NewGuid(), JobId = Guid.NewGuid(), JobName = "manual",
+            Status = "queued", StartedAt = DateTimeOffset.UtcNow, TotalFileCount = 0,
+            CompletedFileCount = 0, SkippedFileCount = 0, FailedFileCount = 0, TotalBytes = 0, DownloadedBytes = 0 };
+        var controller = new SporeSyncJobsController(new FakeSporeSyncJobService(),
             new FakeSyncJobRunService { Result = new SyncJobRunResult { Run = run } });
 
-        var result = await controller.RunNow(run.JobId, CancellationToken.None);
-
-        var accepted = Assert.IsType<AcceptedResult>(result.Result);
-        var response = Assert.IsType<SporeSyncRunResponse>(accepted.Value);
-        Assert.Equal(run.Id, response.Id);
+        var accepted = Assert.IsType<AcceptedResult>((await controller.RunNow(run.JobId, default)).Result);
+        Assert.Equal(run.Id, Assert.IsType<SporeSyncRunResponse>(accepted.Value).Id);
     }
 
     [Fact]

--- a/SporeSync.Business.Tests/SporeSyncOptionsValidationTests.cs
+++ b/SporeSync.Business.Tests/SporeSyncOptionsValidationTests.cs
@@ -29,6 +29,7 @@ public sealed class SporeSyncOptionsValidationTests
     [InlineData("SporeSync:SftpOperationTimeoutSeconds", "-5")]
     [InlineData("SporeSync:DownloadLeaseSeconds", "0")]
     [InlineData("SporeSync:RunScanLeaseSeconds", "0")]
+    [InlineData("SporeSync:ManualRunQueueCapacity", "0")]
     [InlineData("SporeSync:RecoverySweepIntervalSeconds", "0")]
     [InlineData("SporeSync:DownloadMaxRetries", "-1")]
     [InlineData("SporeSync:DownloadRetryBaseDelaySeconds", "0")]

--- a/SporeSync.Business.Tests/Worker/ManualRunHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/Worker/ManualRunHostedServiceTests.cs
@@ -7,25 +7,19 @@ using SporeSync.Business.Service;
 using SporeSync.Business.Worker;
 using SporeSync.Domain.Interface;
 using SporeSync.Domain.Model;
-
 namespace SporeSync.Business.Tests.Worker;
-
 public sealed class ManualRunHostedServiceTests
 {
     private static readonly Guid JobId = Guid.NewGuid();
     private static readonly Guid RunId = Guid.NewGuid();
-
     [Fact]
     public async Task ProcessWorkItem_CreatesAndDisposesScope()
     {
         var harness = new WorkerHarness((_, _, _) => Task.CompletedTask);
-
         await harness.Worker.ProcessWorkItemAsync(new ManualRunWorkItem(JobId, RunId), CancellationToken.None);
-
         Assert.Equal(1, harness.ScanCalls);
         Assert.Equal(1, harness.DisposalCount);
     }
-
     [Fact]
     public async Task ProcessWorkItem_ShutdownTokenCancelsScanAndTerminatesRun()
     {
@@ -37,25 +31,46 @@ public sealed class ManualRunHostedServiceTests
         });
         using var stopping = new CancellationTokenSource();
         stopping.Cancel();
-
         await harness.Worker.ProcessWorkItemAsync(new ManualRunWorkItem(JobId, RunId), stopping.Token);
-
         Assert.Equal(stopping.Token, receivedToken);
         Assert.Equal("cancelled", Assert.Single(harness.TerminalUpdates).Status);
     }
-
     [Fact]
     public async Task ProcessWorkItem_UnexpectedFailureTerminatesRun()
     {
         var harness = new WorkerHarness((_, _, _) => throw new InvalidOperationException("scan exploded"));
-
         await harness.Worker.ProcessWorkItemAsync(new ManualRunWorkItem(JobId, RunId), CancellationToken.None);
-
         var update = Assert.Single(harness.TerminalUpdates);
         Assert.Equal("failed", update.Status);
         Assert.Equal("scan exploded", update.ErrorMessage);
     }
-
+    [Fact]
+    public async Task HostedWorker_RenewsSecondRunWhileFirstRunsPastLease()
+    {
+        TaskCompletionSource firstStarted = new(TaskCreationOptions.RunContinuationsAsynchronously),
+            releaseFirst = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var scanNumber = 0;
+        var harness = new WorkerHarness(async (_, _, token) =>
+        {
+            if (Interlocked.Increment(ref scanNumber) == 1)
+            {
+                firstStarted.SetResult();
+                await releaseFirst.Task.WaitAsync(token);
+            }
+            else secondStarted.SetResult();
+        }, leaseSeconds: 2);
+        var waitingRunId = Guid.NewGuid();
+        harness.Enqueue(new ManualRunWorkItem(JobId, RunId));
+        harness.Enqueue(new ManualRunWorkItem(JobId, waitingRunId));
+        await harness.Worker.StartAsync(CancellationToken.None);
+        await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await Task.Delay(TimeSpan.FromMilliseconds(2200));
+        Assert.Contains(waitingRunId, harness.RenewedRunIds);
+        releaseFirst.SetResult();
+        await secondStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await harness.Worker.StopAsync(CancellationToken.None);
+    }
     [Fact]
     public async Task TriggerManualRun_WhenQueueIsFull_DoesNotCreateRun()
     {
@@ -82,16 +97,15 @@ public sealed class ManualRunHostedServiceTests
             queue,
             CreateNotifier(),
             Options.Create(new SporeSyncOptions()));
-
         var result = await service.TriggerManualRunAsync(JobId);
-
         Assert.Equal(SyncJobRunError.QueueSaturated, result.Error);
         Assert.Equal(0, createCalls);
     }
-
     private sealed class WorkerHarness
     {
-        public WorkerHarness(Func<SporeSyncJob, SporeSyncRun, CancellationToken, Task> scan)
+        public WorkerHarness(
+            Func<SporeSyncJob, SporeSyncRun, CancellationToken, Task> scan,
+            int leaseSeconds = 1800)
         {
             var services = new ServiceCollection();
             services.AddSingleton(Proxy<ISporeSyncJobRepository>((method, _) => method.Name switch
@@ -103,6 +117,7 @@ public sealed class ManualRunHostedServiceTests
             {
                 nameof(ISporeSyncRunRepository.GetByIdAsync) => (object)Task.FromResult<SporeSyncRun?>(CreateRun()),
                 nameof(ISporeSyncRunRepository.UpdateStatusAsync) => RecordUpdate((UpdateSporeSyncRunStatus)args![0]!),
+                nameof(ISporeSyncRunRepository.RenewLeaseAsync) => RecordRenewal((Guid)args![0]!),
                 _ => throw new NotSupportedException(method.Name)
             }));
             services.AddSingleton(CreateNotifier());
@@ -115,38 +130,42 @@ public sealed class ManualRunHostedServiceTests
                     return scan(job, run, token);
                 }));
             Provider = services.BuildServiceProvider();
-            var queue = new ManualRunQueue(Options.Create(new SporeSyncOptions()));
+            Queue = new ManualRunQueue(Options.Create(new SporeSyncOptions { ManualRunQueueCapacity = 2 }));
             Worker = new ManualRunHostedService(
-                queue,
+                Queue,
                 Provider.GetRequiredService<IServiceScopeFactory>(),
+                Options.Create(new SporeSyncOptions { RunScanLeaseSeconds = leaseSeconds }),
                 NullLogger<ManualRunHostedService>.Instance);
         }
-
         public ServiceProvider Provider { get; }
         public ManualRunHostedService Worker { get; }
+        public ManualRunQueue Queue { get; }
         public List<UpdateSporeSyncRunStatus> TerminalUpdates { get; } = [];
+        public System.Collections.Concurrent.ConcurrentQueue<Guid> RenewedRunIds { get; } = [];
         public int ScanCalls { get; private set; }
         public int DisposalCount { get; private set; }
-
         private Task<SporeSyncRun> RecordUpdate(UpdateSporeSyncRunStatus update)
         {
             TerminalUpdates.Add(update);
             return Task.FromResult(CreateRun(update.Status));
         }
+        public void Enqueue(ManualRunWorkItem item)
+        {
+            Assert.True(Queue.TryReserve(out var reservation));
+            reservation!.Enqueue(item);
+        }
+        private Task<bool> RecordRenewal(Guid runId)
+        {
+            RenewedRunIds.Enqueue(runId);
+            return Task.FromResult(true);
+        }
     }
-
-    private sealed class ScopeMarker(Action dispose) : IDisposable
-    {
-        public void Dispose() => dispose();
-    }
-
+    private sealed class ScopeMarker(Action dispose) : IDisposable { public void Dispose() => dispose(); }
     private sealed class TestOrchestrator(
         ScopeMarker marker,
         Func<SporeSyncJob, SporeSyncRun, CancellationToken, Task> scan) : ISyncRunOrchestrator
     {
-        public async Task<SporeSyncRun> ScanAsync(
-            SporeSyncJob job,
-            SporeSyncRun run,
+        public async Task<SporeSyncRun> ScanAsync(SporeSyncJob job, SporeSyncRun run,
             CancellationToken cancellationToken = default)
         {
             GC.KeepAlive(marker);
@@ -154,49 +173,27 @@ public sealed class ManualRunHostedServiceTests
             return run;
         }
     }
-
-    private static SporeSyncJob CreateJob() => new()
-    {
-        Id = JobId,
-        ConnectionProfileId = Guid.NewGuid(),
-        Name = "manual",
-        SourcePath = "/source",
-        DestinationPath = "/destination",
-        IsEnabled = true
-    };
-
+    private static SporeSyncJob CreateJob() => new() { Id = JobId, ConnectionProfileId = Guid.NewGuid(),
+        Name = "manual", SourcePath = "/source", DestinationPath = "/destination", IsEnabled = true };
     private static SporeSyncRun CreateRun(string status = "queued") => new()
     {
-        Id = RunId,
-        JobId = JobId,
-        JobName = "manual",
-        Status = status,
-        StartedAt = DateTimeOffset.UtcNow,
-        TotalFileCount = 0,
-        CompletedFileCount = 0,
-        SkippedFileCount = 0,
-        FailedFileCount = 0,
-        TotalBytes = 0,
-        DownloadedBytes = 0
+        Id = RunId, JobId = JobId, JobName = "manual", Status = status,
+        StartedAt = DateTimeOffset.UtcNow, TotalFileCount = 0, CompletedFileCount = 0,
+        SkippedFileCount = 0, FailedFileCount = 0, TotalBytes = 0, DownloadedBytes = 0
     };
-
     private static ISyncDashboardNotifier CreateNotifier() => Proxy<ISyncDashboardNotifier>((method, _) =>
-        method.Name is nameof(ISyncDashboardNotifier.NotifyRunUpdatedAsync)
-            or nameof(ISyncDashboardNotifier.NotifyQueueItemUpdatedAsync)
-                ? Task.CompletedTask
-                : throw new NotSupportedException(method.Name));
-
+        method.Name is nameof(ISyncDashboardNotifier.NotifyRunUpdatedAsync) or
+            nameof(ISyncDashboardNotifier.NotifyQueueItemUpdatedAsync) ? Task.CompletedTask :
+            throw new NotSupportedException(method.Name));
     private static T Proxy<T>(Func<MethodInfo, object?[]?, object?> handler) where T : class
     {
         var proxy = DispatchProxy.Create<T, TestDispatchProxy>();
         ((TestDispatchProxy)(object)proxy).Handler = handler;
         return proxy;
     }
-
     private class TestDispatchProxy : DispatchProxy
     {
         public required Func<MethodInfo, object?[]?, object?> Handler { private get; set; }
-
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) => Handler(targetMethod!, args);
     }
 }

--- a/SporeSync.Business.Tests/Worker/ManualRunHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/Worker/ManualRunHostedServiceTests.cs
@@ -1,0 +1,202 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SporeSync.Business.Interface;
+using SporeSync.Business.Service;
+using SporeSync.Business.Worker;
+using SporeSync.Domain.Interface;
+using SporeSync.Domain.Model;
+
+namespace SporeSync.Business.Tests.Worker;
+
+public sealed class ManualRunHostedServiceTests
+{
+    private static readonly Guid JobId = Guid.NewGuid();
+    private static readonly Guid RunId = Guid.NewGuid();
+
+    [Fact]
+    public async Task ProcessWorkItem_CreatesAndDisposesScope()
+    {
+        var harness = new WorkerHarness((_, _, _) => Task.CompletedTask);
+
+        await harness.Worker.ProcessWorkItemAsync(new ManualRunWorkItem(JobId, RunId), CancellationToken.None);
+
+        Assert.Equal(1, harness.ScanCalls);
+        Assert.Equal(1, harness.DisposalCount);
+    }
+
+    [Fact]
+    public async Task ProcessWorkItem_ShutdownTokenCancelsScanAndTerminatesRun()
+    {
+        CancellationToken receivedToken = default;
+        var harness = new WorkerHarness((_, _, token) =>
+        {
+            receivedToken = token;
+            throw new OperationCanceledException(token);
+        });
+        using var stopping = new CancellationTokenSource();
+        stopping.Cancel();
+
+        await harness.Worker.ProcessWorkItemAsync(new ManualRunWorkItem(JobId, RunId), stopping.Token);
+
+        Assert.Equal(stopping.Token, receivedToken);
+        Assert.Equal("cancelled", Assert.Single(harness.TerminalUpdates).Status);
+    }
+
+    [Fact]
+    public async Task ProcessWorkItem_UnexpectedFailureTerminatesRun()
+    {
+        var harness = new WorkerHarness((_, _, _) => throw new InvalidOperationException("scan exploded"));
+
+        await harness.Worker.ProcessWorkItemAsync(new ManualRunWorkItem(JobId, RunId), CancellationToken.None);
+
+        var update = Assert.Single(harness.TerminalUpdates);
+        Assert.Equal("failed", update.Status);
+        Assert.Equal("scan exploded", update.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task TriggerManualRun_WhenQueueIsFull_DoesNotCreateRun()
+    {
+        var queue = new ManualRunQueue(Options.Create(new SporeSyncOptions { ManualRunQueueCapacity = 1 }));
+        Assert.True(queue.TryReserve(out var occupied));
+        occupied!.Enqueue(new ManualRunWorkItem(Guid.NewGuid(), Guid.NewGuid()));
+        var createCalls = 0;
+        var jobRepository = Proxy<ISporeSyncJobRepository>((method, _) => method.Name switch
+        {
+            nameof(ISporeSyncJobRepository.GetByIdAsync) => Task.FromResult<SporeSyncJob?>(CreateJob()),
+            _ => throw new NotSupportedException(method.Name)
+        });
+        var runRepository = Proxy<ISporeSyncRunRepository>((method, _) =>
+        {
+            if (method.Name == nameof(ISporeSyncRunRepository.TryCreateAsync))
+            {
+                createCalls++;
+            }
+            throw new NotSupportedException(method.Name);
+        });
+        var service = new SyncJobRunService(
+            jobRepository,
+            runRepository,
+            queue,
+            CreateNotifier(),
+            Options.Create(new SporeSyncOptions()));
+
+        var result = await service.TriggerManualRunAsync(JobId);
+
+        Assert.Equal(SyncJobRunError.QueueSaturated, result.Error);
+        Assert.Equal(0, createCalls);
+    }
+
+    private sealed class WorkerHarness
+    {
+        public WorkerHarness(Func<SporeSyncJob, SporeSyncRun, CancellationToken, Task> scan)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(Proxy<ISporeSyncJobRepository>((method, _) => method.Name switch
+            {
+                nameof(ISporeSyncJobRepository.GetByIdAsync) => Task.FromResult<SporeSyncJob?>(CreateJob()),
+                _ => throw new NotSupportedException(method.Name)
+            }));
+            services.AddSingleton(Proxy<ISporeSyncRunRepository>((method, args) => method.Name switch
+            {
+                nameof(ISporeSyncRunRepository.GetByIdAsync) => (object)Task.FromResult<SporeSyncRun?>(CreateRun()),
+                nameof(ISporeSyncRunRepository.UpdateStatusAsync) => RecordUpdate((UpdateSporeSyncRunStatus)args![0]!),
+                _ => throw new NotSupportedException(method.Name)
+            }));
+            services.AddSingleton(CreateNotifier());
+            services.AddScoped(_ => new ScopeMarker(() => DisposalCount++));
+            services.AddScoped<ISyncRunOrchestrator>(provider => new TestOrchestrator(
+                provider.GetRequiredService<ScopeMarker>(),
+                (job, run, token) =>
+                {
+                    ScanCalls++;
+                    return scan(job, run, token);
+                }));
+            Provider = services.BuildServiceProvider();
+            var queue = new ManualRunQueue(Options.Create(new SporeSyncOptions()));
+            Worker = new ManualRunHostedService(
+                queue,
+                Provider.GetRequiredService<IServiceScopeFactory>(),
+                NullLogger<ManualRunHostedService>.Instance);
+        }
+
+        public ServiceProvider Provider { get; }
+        public ManualRunHostedService Worker { get; }
+        public List<UpdateSporeSyncRunStatus> TerminalUpdates { get; } = [];
+        public int ScanCalls { get; private set; }
+        public int DisposalCount { get; private set; }
+
+        private Task<SporeSyncRun> RecordUpdate(UpdateSporeSyncRunStatus update)
+        {
+            TerminalUpdates.Add(update);
+            return Task.FromResult(CreateRun(update.Status));
+        }
+    }
+
+    private sealed class ScopeMarker(Action dispose) : IDisposable
+    {
+        public void Dispose() => dispose();
+    }
+
+    private sealed class TestOrchestrator(
+        ScopeMarker marker,
+        Func<SporeSyncJob, SporeSyncRun, CancellationToken, Task> scan) : ISyncRunOrchestrator
+    {
+        public async Task<SporeSyncRun> ScanAsync(
+            SporeSyncJob job,
+            SporeSyncRun run,
+            CancellationToken cancellationToken = default)
+        {
+            GC.KeepAlive(marker);
+            await scan(job, run, cancellationToken);
+            return run;
+        }
+    }
+
+    private static SporeSyncJob CreateJob() => new()
+    {
+        Id = JobId,
+        ConnectionProfileId = Guid.NewGuid(),
+        Name = "manual",
+        SourcePath = "/source",
+        DestinationPath = "/destination",
+        IsEnabled = true
+    };
+
+    private static SporeSyncRun CreateRun(string status = "queued") => new()
+    {
+        Id = RunId,
+        JobId = JobId,
+        JobName = "manual",
+        Status = status,
+        StartedAt = DateTimeOffset.UtcNow,
+        TotalFileCount = 0,
+        CompletedFileCount = 0,
+        SkippedFileCount = 0,
+        FailedFileCount = 0,
+        TotalBytes = 0,
+        DownloadedBytes = 0
+    };
+
+    private static ISyncDashboardNotifier CreateNotifier() => Proxy<ISyncDashboardNotifier>((method, _) =>
+        method.Name is nameof(ISyncDashboardNotifier.NotifyRunUpdatedAsync)
+            or nameof(ISyncDashboardNotifier.NotifyQueueItemUpdatedAsync)
+                ? Task.CompletedTask
+                : throw new NotSupportedException(method.Name));
+
+    private static T Proxy<T>(Func<MethodInfo, object?[]?, object?> handler) where T : class
+    {
+        var proxy = DispatchProxy.Create<T, TestDispatchProxy>();
+        ((TestDispatchProxy)(object)proxy).Handler = handler;
+        return proxy;
+    }
+
+    private class TestDispatchProxy : DispatchProxy
+    {
+        public required Func<MethodInfo, object?[]?, object?> Handler { private get; set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) => Handler(targetMethod!, args);
+    }
+}

--- a/SporeSync.Business/Interface/ISyncJobRunService.cs
+++ b/SporeSync.Business/Interface/ISyncJobRunService.cs
@@ -6,7 +6,8 @@ public enum SyncJobRunError
 {
     NotFound,
     Disabled,
-    ActiveRunExists
+    ActiveRunExists,
+    QueueSaturated
 }
 
 public sealed class SyncJobRunResult

--- a/SporeSync.Business/Service/SyncJobRunService.cs
+++ b/SporeSync.Business/Service/SyncJobRunService.cs
@@ -9,20 +9,20 @@ public sealed class SyncJobRunService : ISyncJobRunService
 {
     private readonly ISporeSyncJobRepository _jobRepository;
     private readonly ISporeSyncRunRepository _runRepository;
-    private readonly ISyncRunOrchestrator _orchestrator;
+    private readonly IManualRunQueue _manualRunQueue;
     private readonly ISyncDashboardNotifier _notifier;
     private readonly SporeSyncOptions _options;
 
     public SyncJobRunService(
         ISporeSyncJobRepository jobRepository,
         ISporeSyncRunRepository runRepository,
-        ISyncRunOrchestrator orchestrator,
+        IManualRunQueue manualRunQueue,
         ISyncDashboardNotifier notifier,
         IOptions<SporeSyncOptions> options)
     {
         _jobRepository = jobRepository;
         _runRepository = runRepository;
-        _orchestrator = orchestrator;
+        _manualRunQueue = manualRunQueue;
         _notifier = notifier;
         _options = options.Value;
     }
@@ -42,28 +42,24 @@ public sealed class SyncJobRunService : ISyncJobRunService
             return new SyncJobRunResult { Error = SyncJobRunError.Disabled };
         }
 
-        // Creation is atomic: null means another caller (scheduler or a concurrent
-        // manual trigger) created an active run first.
-        var run = await _runRepository.TryCreateAsync(jobId, _options.RunScanLeaseSeconds, cancellationToken);
-        if (run is null)
+        if (!_manualRunQueue.TryReserve(out var reservation))
         {
-            return new SyncJobRunResult { Error = SyncJobRunError.ActiveRunExists };
+            return new SyncJobRunResult { Error = SyncJobRunError.QueueSaturated };
         }
 
-        await _notifier.NotifyRunUpdatedAsync(run, cancellationToken);
-
-        _ = Task.Run(async () =>
+        using (reservation)
         {
-            try
+            // Creation is atomic: null means another caller (scheduler or a concurrent
+            // manual trigger) created an active run first.
+            var run = await _runRepository.TryCreateAsync(jobId, _options.RunScanLeaseSeconds, cancellationToken);
+            if (run is null)
             {
-                await _orchestrator.ScanAsync(job, run, CancellationToken.None);
+                return new SyncJobRunResult { Error = SyncJobRunError.ActiveRunExists };
             }
-            catch
-            {
-                // Errors are persisted on the run by the orchestrator.
-            }
-        }, CancellationToken.None);
 
-        return new SyncJobRunResult { Run = run };
+            reservation!.Enqueue(new ManualRunWorkItem(jobId, run.Id));
+            await _notifier.NotifyRunUpdatedAsync(run, cancellationToken);
+            return new SyncJobRunResult { Run = run };
+        }
     }
 }

--- a/SporeSync.Business/ServiceExtension.cs
+++ b/SporeSync.Business/ServiceExtension.cs
@@ -43,12 +43,15 @@ public static class ServiceExtension
         services.AddSingleton<DownloadRetryPolicy>();
         services.AddScoped<IChangeDetector, ChangeDetector>();
         services.AddScoped<ISyncRunOrchestrator, SyncRunOrchestrator>();
+        services.AddSingleton<ManualRunQueue>();
+        services.AddSingleton<IManualRunQueue>(provider => provider.GetRequiredService<ManualRunQueue>());
         services.AddScoped<ISyncJobRunService, SyncJobRunService>();
         services.AddScoped<ISyncRunControlService, SyncRunControlService>();
         services.AddScoped<ISftpConnectionTestService, SftpConnectionTestService>();
         // Recovery must be registered (and therefore started) before the scheduler
         // and download worker so the startup sweep completes before new work begins.
         services.AddHostedService<QueueRecoveryHostedService>();
+        services.AddHostedService<ManualRunHostedService>();
         services.AddHostedService<JobSchedulerHostedService>();
         services.AddHostedService<DownloadWorkerHostedService>();
         services.AddHostedService<RetentionPruningHostedService>();

--- a/SporeSync.Business/SporeSyncOptions.cs
+++ b/SporeSync.Business/SporeSyncOptions.cs
@@ -37,6 +37,10 @@ public sealed class SporeSyncOptions
     [Range(1, 86_400)]
     public int RunScanLeaseSeconds { get; set; } = 1800;
 
+    /// <summary>Maximum number of manual scans waiting for the background worker.</summary>
+    [Range(1, 10_000)]
+    public int ManualRunQueueCapacity { get; set; } = 32;
+
     /// <summary>
     /// Interval between periodic recovery sweeps (stale item requeue and orphaned
     /// run reaping).

--- a/SporeSync.Business/Worker/ManualRunHostedService.cs
+++ b/SporeSync.Business/Worker/ManualRunHostedService.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SporeSync.Business.Interface;
+using SporeSync.Domain.Interface;
+using SporeSync.Domain.Model;
+
+namespace SporeSync.Business.Worker;
+
+public sealed class ManualRunHostedService : BackgroundService
+{
+    private readonly ManualRunQueue _queue;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ManualRunHostedService> _logger;
+
+    public ManualRunHostedService(
+        ManualRunQueue queue,
+        IServiceScopeFactory scopeFactory,
+        ILogger<ManualRunHostedService> logger)
+    {
+        _queue = queue;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var item = await _queue.ReadAsync(stoppingToken);
+                await ProcessWorkItemAsync(item, stoppingToken);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal hosted-service shutdown.
+        }
+        finally
+        {
+            while (_queue.TryRead(out var pending))
+            {
+                await TerminateRunAsync(pending!.RunId, "cancelled", null);
+            }
+        }
+    }
+
+    internal async Task ProcessWorkItemAsync(ManualRunWorkItem item, CancellationToken stoppingToken)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var jobRepository = scope.ServiceProvider.GetRequiredService<ISporeSyncJobRepository>();
+            var runRepository = scope.ServiceProvider.GetRequiredService<ISporeSyncRunRepository>();
+            var orchestrator = scope.ServiceProvider.GetRequiredService<ISyncRunOrchestrator>();
+
+            var job = await jobRepository.GetByIdAsync(item.JobId, stoppingToken)
+                ?? throw new InvalidOperationException($"Sync job '{item.JobId}' no longer exists.");
+            var run = await runRepository.GetByIdAsync(item.RunId, stoppingToken)
+                ?? throw new InvalidOperationException($"Sync run '{item.RunId}' no longer exists.");
+
+            await orchestrator.ScanAsync(job, run, stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Manual scan for run {RunId} stopped during application shutdown.", item.RunId);
+            await TerminateRunAsync(item.RunId, "cancelled", null);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Manual scan failed unexpectedly for job {JobId} run {RunId}.", item.JobId, item.RunId);
+            await TerminateRunAsync(item.RunId, "failed", ex.Message);
+        }
+    }
+
+    private async Task TerminateRunAsync(Guid runId, string status, string? errorMessage)
+    {
+        try
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var runRepository = scope.ServiceProvider.GetRequiredService<ISporeSyncRunRepository>();
+            var notifier = scope.ServiceProvider.GetRequiredService<ISyncDashboardNotifier>();
+            var run = await runRepository.UpdateStatusAsync(new UpdateSporeSyncRunStatus
+            {
+                Id = runId,
+                Status = status,
+                ErrorMessage = errorMessage
+            }, CancellationToken.None);
+            await notifier.NotifyRunUpdatedAsync(run, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not persist terminal status {Status} for manual run {RunId}.", status, runId);
+        }
+    }
+}

--- a/SporeSync.Business/Worker/ManualRunHostedService.cs
+++ b/SporeSync.Business/Worker/ManualRunHostedService.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using SporeSync.Business.Interface;
 using SporeSync.Domain.Interface;
 using SporeSync.Domain.Model;
@@ -12,19 +13,24 @@ public sealed class ManualRunHostedService : BackgroundService
     private readonly ManualRunQueue _queue;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<ManualRunHostedService> _logger;
+    private readonly SporeSyncOptions _options;
 
     public ManualRunHostedService(
         ManualRunQueue queue,
         IServiceScopeFactory scopeFactory,
+        IOptions<SporeSyncOptions> options,
         ILogger<ManualRunHostedService> logger)
     {
         _queue = queue;
         _scopeFactory = scopeFactory;
+        _options = options.Value;
         _logger = logger;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        using var renewalCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+        var leaseRenewalTask = RenewQueuedLeasesAsync(renewalCts.Token);
         try
         {
             while (!stoppingToken.IsCancellationRequested)
@@ -33,15 +39,40 @@ public sealed class ManualRunHostedService : BackgroundService
                 await ProcessWorkItemAsync(item, stoppingToken);
             }
         }
-        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-        {
-            // Normal hosted-service shutdown.
-        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
         finally
         {
+            renewalCts.Cancel();
+            await leaseRenewalTask;
             while (_queue.TryRead(out var pending))
             {
                 await TerminateRunAsync(pending!.RunId, "cancelled", null);
+            }
+        }
+    }
+
+    private async Task RenewQueuedLeasesAsync(CancellationToken stoppingToken)
+    {
+        var interval = TimeSpan.FromSeconds(Math.Max(1, _options.RunScanLeaseSeconds / 3.0));
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(interval, stoppingToken);
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var repository = scope.ServiceProvider.GetRequiredService<ISporeSyncRunRepository>();
+                foreach (var runId in _queue.GetQueuedRunIds())
+                {
+                    await repository.RenewLeaseAsync(runId, _options.RunScanLeaseSeconds, stoppingToken);
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Queued manual-run lease renewal failed; retrying.");
             }
         }
     }

--- a/SporeSync.Business/Worker/ManualRunQueue.cs
+++ b/SporeSync.Business/Worker/ManualRunQueue.cs
@@ -1,0 +1,85 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Options;
+
+namespace SporeSync.Business.Worker;
+
+public sealed record ManualRunWorkItem(Guid JobId, Guid RunId);
+
+public interface IManualRunQueue
+{
+    bool TryReserve(out ManualRunQueueReservation? reservation);
+}
+
+public sealed class ManualRunQueueReservation : IDisposable
+{
+    private ManualRunQueue? _queue;
+
+    internal ManualRunQueueReservation(ManualRunQueue queue) => _queue = queue;
+
+    public void Enqueue(ManualRunWorkItem item)
+    {
+        var queue = Interlocked.Exchange(ref _queue, null)
+            ?? throw new InvalidOperationException("The queue reservation has already been used.");
+        queue.EnqueueReserved(item);
+    }
+
+    public void Dispose() => Interlocked.Exchange(ref _queue, null)?.ReleaseReservation();
+}
+
+public sealed class ManualRunQueue : IManualRunQueue
+{
+    private readonly Channel<ManualRunWorkItem> _channel;
+    private readonly SemaphoreSlim _availableSlots;
+
+    public ManualRunQueue(IOptions<SporeSyncOptions> options)
+    {
+        var capacity = options.Value.ManualRunQueueCapacity;
+        _channel = Channel.CreateBounded<ManualRunWorkItem>(new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true
+        });
+        _availableSlots = new SemaphoreSlim(capacity, capacity);
+    }
+
+    public bool TryReserve(out ManualRunQueueReservation? reservation)
+    {
+        if (!_availableSlots.Wait(0))
+        {
+            reservation = null;
+            return false;
+        }
+
+        reservation = new ManualRunQueueReservation(this);
+        return true;
+    }
+
+    internal async ValueTask<ManualRunWorkItem> ReadAsync(CancellationToken cancellationToken)
+    {
+        var item = await _channel.Reader.ReadAsync(cancellationToken);
+        _availableSlots.Release();
+        return item;
+    }
+
+    internal bool TryRead(out ManualRunWorkItem? item)
+    {
+        if (!_channel.Reader.TryRead(out item))
+        {
+            return false;
+        }
+
+        _availableSlots.Release();
+        return true;
+    }
+
+    internal void EnqueueReserved(ManualRunWorkItem item)
+    {
+        if (!_channel.Writer.TryWrite(item))
+        {
+            _availableSlots.Release();
+            throw new InvalidOperationException("A reserved manual-run queue slot could not be committed.");
+        }
+    }
+
+    internal void ReleaseReservation() => _availableSlots.Release();
+}

--- a/SporeSync.Business/Worker/ManualRunQueue.cs
+++ b/SporeSync.Business/Worker/ManualRunQueue.cs
@@ -30,6 +30,7 @@ public sealed class ManualRunQueue : IManualRunQueue
 {
     private readonly Channel<ManualRunWorkItem> _channel;
     private readonly SemaphoreSlim _availableSlots;
+    private readonly HashSet<Guid> _queuedRunIds = [];
 
     public ManualRunQueue(IOptions<SporeSyncOptions> options)
     {
@@ -57,6 +58,7 @@ public sealed class ManualRunQueue : IManualRunQueue
     internal async ValueTask<ManualRunWorkItem> ReadAsync(CancellationToken cancellationToken)
     {
         var item = await _channel.Reader.ReadAsync(cancellationToken);
+        lock (_queuedRunIds) _queuedRunIds.Remove(item.RunId);
         _availableSlots.Release();
         return item;
     }
@@ -68,18 +70,23 @@ public sealed class ManualRunQueue : IManualRunQueue
             return false;
         }
 
+        lock (_queuedRunIds) _queuedRunIds.Remove(item.RunId);
         _availableSlots.Release();
         return true;
     }
 
     internal void EnqueueReserved(ManualRunWorkItem item)
     {
+        lock (_queuedRunIds) _queuedRunIds.Add(item.RunId);
         if (!_channel.Writer.TryWrite(item))
         {
+            lock (_queuedRunIds) _queuedRunIds.Remove(item.RunId);
             _availableSlots.Release();
             throw new InvalidOperationException("A reserved manual-run queue slot could not be committed.");
         }
     }
+
+    internal Guid[] GetQueuedRunIds() { lock (_queuedRunIds) return [.. _queuedRunIds]; }
 
     internal void ReleaseReservation() => _availableSlots.Release();
 }

--- a/SporeSync.Web/Controllers/SporeSyncJobsController.cs
+++ b/SporeSync.Web/Controllers/SporeSyncJobsController.cs
@@ -113,6 +113,10 @@ public sealed class SporeSyncJobsController : ControllerBase
                 statusCode: StatusCodes.Status409Conflict,
                 title: "Run already active.",
                 detail: "Job already has an active run."),
+            SyncJobRunError.QueueSaturated => Problem(
+                statusCode: StatusCodes.Status429TooManyRequests,
+                title: "Manual run queue is full.",
+                detail: "Try the request again after an existing manual scan starts."),
             _ => Accepted(SyncDashboardNotifier.ToRunResponse(result.Run!))
         };
     }


### PR DESCRIPTION
Closes #18

## Summary
- replace request-scoped `Task.Run` scans with a bounded manual-run queue and hosted worker
- reserve queue capacity before run creation, returning HTTP 429 on saturation without creating an orphan run
- create and dispose a fresh DI scope per scan, propagate the host stopping token, and persist/log terminal cancellation or failure
- add focused coverage for 202 responses, scope disposal, shutdown, unexpected failures, saturation, and option validation

## Validation
- `dotnet build SporeSync.sln --no-restore` — passed (5 pre-existing package warnings)
- `dotnet test SporeSync.sln --no-build` — passed (265 tests)
- focused manual-run/controller/options tests — passed (20 tests)

No frontend code was changed, so frontend checks were not applicable.