### PR TITLE
Add automatic download retries with bounded backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,31 @@ Worker settings in `appsettings.json`:
     "DownloadPollIntervalMs": 1000,
     "SftpConnectionTimeoutSeconds": 30,
     "SftpOperationTimeoutSeconds": 300,
+    "DownloadMaxRetries": 3,
+    "DownloadRetryBaseDelaySeconds": 30,
+    "DownloadRetryMaxDelaySeconds": 900,
+    "DownloadRetryJitterRatio": 0.2,
     "RunHistoryRetentionDays": 30,
     "RetentionSweepIntervalHours": 6
   }
 }
 ```
+
+Failed downloads are retried within the same sync run. `DownloadMaxRetries` is
+the number of retries after the initial attempt. Retry delays use bounded
+exponential backoff with proportional jitter: the base delay is the lower
+bound, the maximum delay is the upper bound, and `DownloadRetryJitterRatio`
+controls random variation (for example, `0.2` means up to 20% above or below
+the exponential delay before clamping).
+
+Connection, remote I/O, interrupted transfer, and size-verification failures
+are classified as transient. Unsafe destination paths are classified as
+permanent and fail immediately without consuming retry budget. Exhausted
+transient items end in `failed` with `retry_budget_exhausted`; permanent items
+use `permanent_error`. Backoff is stored as a queue eligibility timestamp, so
+the worker remains available for unrelated items instead of sleeping. Shutdown
+cancels the normal worker poll immediately; there is no in-memory retry delay
+to hold shutdown open, and scheduled retries remain durable for the next start.
 
 ### Authentication
 

--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -1158,8 +1158,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.TryCreateAsync(job.Id);
-        Assert.NotNull(run);
+        var run = Assert.IsType<SporeSyncRun>(await runRepository.TryCreateAsync(job.Id));
 
         Assert.Equal(SafeDeleteSporeSyncJobResult.ActiveRunExists, await jobRepository.SafeDeleteAsync(job.Id));
         Assert.NotNull(await jobRepository.GetByIdAsync(job.Id));

--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -1196,7 +1196,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.TryCreateAsync(job.Id);
+        var run = Assert.IsType<SporeSyncRun>(await runRepository.TryCreateAsync(job.Id));
 
         var scanning = await runRepository.AdvanceScanStatusAsync(new UpdateSporeSyncRunStatus
         {

--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -696,6 +696,11 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
         var claimedTooEarly = await ClaimSpecificAsync(queueRepository, item.Id);
         Assert.Null(claimedTooEarly);
 
+        // A delayed retry does not occupy the worker or block unrelated queued work.
+        var unrelated = await SeedClaimableItemAsync(queueRepository, "/incoming/unrelated.csv");
+        var claimedUnrelated = await ClaimSpecificAsync(queueRepository, unrelated.Id);
+        Assert.NotNull(claimedUnrelated);
+
         // Fail with a past next attempt: immediately claimable again.
         await queueRepository.RecordFailureAsync(
             item.Id,

--- a/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
@@ -248,7 +248,8 @@ public sealed class SftpSyncEndToEndTests :
         var orchestrator = scope.ServiceProvider.GetRequiredService<ISyncRunOrchestrator>();
         var worker = _provider.GetRequiredService<DownloadWorkerHostedService>();
         var job = await CreateJobAsync(scope.ServiceProvider, caseRoot, "retry-success");
-        var run = await orchestrator.ScanAsync(job, await runRepository.TryCreateAsync(job.Id));
+        var queuedRun = Assert.IsType<SporeSyncRun>(await runRepository.TryCreateAsync(job.Id));
+        var run = await orchestrator.ScanAsync(job, queuedRun);
 
         await _sftp.DeleteFileAsync(remotePath);
         Assert.True(await worker.ProcessNextItemAsync(CancellationToken.None));
@@ -282,7 +283,8 @@ public sealed class SftpSyncEndToEndTests :
         var orchestrator = scope.ServiceProvider.GetRequiredService<ISyncRunOrchestrator>();
         var worker = _provider.GetRequiredService<DownloadWorkerHostedService>();
         var job = await CreateJobAsync(scope.ServiceProvider, caseRoot, "retry-exhaustion");
-        var run = await orchestrator.ScanAsync(job, await runRepository.TryCreateAsync(job.Id));
+        var queuedRun = Assert.IsType<SporeSyncRun>(await runRepository.TryCreateAsync(job.Id));
+        var run = await orchestrator.ScanAsync(job, queuedRun);
 
         await _sftp.DeleteFileAsync(remotePath);
         Assert.True(await worker.ProcessNextItemAsync(CancellationToken.None));

--- a/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
@@ -49,6 +49,10 @@ public sealed class SftpSyncEndToEndTests :
             options.SftpConnectionTimeoutSeconds = 30;
             options.SftpOperationTimeoutSeconds = 60;
             options.RemoteFileStabilityWindowSeconds = 0;
+            options.DownloadMaxRetries = 1;
+            options.DownloadRetryBaseDelaySeconds = 1;
+            options.DownloadRetryMaxDelaySeconds = 1;
+            options.DownloadRetryJitterRatio = 0.2;
         });
         services.AddSingleton<IEncryptionKeyProvider>(keyProvider);
         services.AddSingleton<ISecretProtector, SecretProtector>();
@@ -229,6 +233,71 @@ public sealed class SftpSyncEndToEndTests :
         var rotating = await CreateProfileAsync(services, "rotation", [other, observed]);
         await using var connection = await factory.ConnectAsync(rotating.Id);
         Assert.True(connection.IsConnected);
+    }
+
+    [Fact]
+    public async Task TransientFailure_RetriesInSameRun_AndEventuallyCompletes()
+    {
+        var caseRoot = $"{SftpTestcontainerFixture.RemoteRoot}/retry-success";
+        var remotePath = $"{caseRoot}/eventual.txt";
+        await _sftp.WriteFileAsync(remotePath, "initial");
+
+        using var scope = _provider.CreateScope();
+        var runRepository = scope.ServiceProvider.GetRequiredService<ISporeSyncRunRepository>();
+        var queueRepository = scope.ServiceProvider.GetRequiredService<IDownloadQueueItemRepository>();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<ISyncRunOrchestrator>();
+        var worker = _provider.GetRequiredService<DownloadWorkerHostedService>();
+        var job = await CreateJobAsync(scope.ServiceProvider, caseRoot, "retry-success");
+        var run = await orchestrator.ScanAsync(job, await runRepository.TryCreateAsync(job.Id));
+
+        await _sftp.DeleteFileAsync(remotePath);
+        Assert.True(await worker.ProcessNextItemAsync(CancellationToken.None));
+
+        var afterFailure = Assert.Single((await queueRepository.GetByRunIdAsync(run.Id, new QueueItemQuery())).Items);
+        Assert.Equal("queued", afterFailure.Status);
+        Assert.Equal(1, afterFailure.RetryCount);
+        Assert.Equal("retry_scheduled", afterFailure.HandledReason);
+
+        await _sftp.WriteFileAsync(remotePath, "available after retry");
+        await Task.Delay(TimeSpan.FromMilliseconds(1100));
+        Assert.True(await worker.ProcessNextItemAsync(CancellationToken.None));
+
+        var completedItem = Assert.Single((await queueRepository.GetByRunIdAsync(run.Id, new QueueItemQuery())).Items);
+        Assert.Equal("completed", completedItem.Status);
+        Assert.Equal(1, completedItem.RetryCount);
+        Assert.Equal("completed", (await runRepository.GetByIdAsync(run.Id))!.Status);
+        Assert.Equal("available after retry", await File.ReadAllTextAsync(Path.Combine(DestinationFor("retry-success"), "eventual.txt")));
+    }
+
+    [Fact]
+    public async Task TransientFailure_ExhaustsRetryBudget_WithTerminalError()
+    {
+        var caseRoot = $"{SftpTestcontainerFixture.RemoteRoot}/retry-exhaustion";
+        var remotePath = $"{caseRoot}/missing.txt";
+        await _sftp.WriteFileAsync(remotePath, "disappearing");
+
+        using var scope = _provider.CreateScope();
+        var runRepository = scope.ServiceProvider.GetRequiredService<ISporeSyncRunRepository>();
+        var queueRepository = scope.ServiceProvider.GetRequiredService<IDownloadQueueItemRepository>();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<ISyncRunOrchestrator>();
+        var worker = _provider.GetRequiredService<DownloadWorkerHostedService>();
+        var job = await CreateJobAsync(scope.ServiceProvider, caseRoot, "retry-exhaustion");
+        var run = await orchestrator.ScanAsync(job, await runRepository.TryCreateAsync(job.Id));
+
+        await _sftp.DeleteFileAsync(remotePath);
+        Assert.True(await worker.ProcessNextItemAsync(CancellationToken.None));
+        await Task.Delay(TimeSpan.FromMilliseconds(1100));
+        Assert.True(await worker.ProcessNextItemAsync(CancellationToken.None));
+
+        var failedItem = Assert.Single((await queueRepository.GetByRunIdAsync(run.Id, new QueueItemQuery())).Items);
+        Assert.Equal("failed", failedItem.Status);
+        Assert.Equal(2, failedItem.RetryCount);
+        Assert.Equal("retry_budget_exhausted", failedItem.HandledReason);
+        Assert.False(string.IsNullOrWhiteSpace(failedItem.ErrorMessage));
+
+        var completedRun = await runRepository.GetByIdAsync(run.Id);
+        Assert.Equal("completed", completedRun!.Status);
+        Assert.Equal(1, completedRun.FailedFileCount);
     }
 
     private async Task<SporeSyncJob> CreateJobAsync(

--- a/SporeSync.Business.Tests/SftpFileDownloaderTests.cs
+++ b/SporeSync.Business.Tests/SftpFileDownloaderTests.cs
@@ -36,6 +36,7 @@ public sealed class SftpFileDownloaderTests : IDisposable
             Path.Combine(_root, "..", "outside.txt"));
 
         Assert.False(result.Success);
+        Assert.Equal(DownloadFailureKind.Permanent, result.FailureKind);
         Assert.Equal(0, factory.ConnectCalls);
         Assert.Contains("configured destination root", result.ErrorMessage);
     }

--- a/SporeSync.Business.Tests/SporeSyncOptionsValidationTests.cs
+++ b/SporeSync.Business.Tests/SporeSyncOptionsValidationTests.cs
@@ -30,6 +30,10 @@ public sealed class SporeSyncOptionsValidationTests
     [InlineData("SporeSync:DownloadLeaseSeconds", "0")]
     [InlineData("SporeSync:RunScanLeaseSeconds", "0")]
     [InlineData("SporeSync:RecoverySweepIntervalSeconds", "0")]
+    [InlineData("SporeSync:DownloadMaxRetries", "-1")]
+    [InlineData("SporeSync:DownloadRetryBaseDelaySeconds", "0")]
+    [InlineData("SporeSync:DownloadRetryMaxDelaySeconds", "0")]
+    [InlineData("SporeSync:DownloadRetryJitterRatio", "1.1")]
     [InlineData("SporeSync:RunHistoryRetentionDays", "-1")]
     [InlineData("SporeSync:RetentionSweepIntervalHours", "0")]
     public void OutOfRangeValue_FailsValidation(string key, string value)
@@ -61,6 +65,18 @@ public sealed class SporeSyncOptionsValidationTests
         Assert.Equal(0, options.Value.RunHistoryRetentionDays);
     }
 
+    [Fact]
+    public void RetryMaximumBelowBaseDelay_FailsValidation()
+    {
+        var options = ResolveOptions(new Dictionary<string, string?>
+        {
+            ["SporeSync:DownloadRetryBaseDelaySeconds"] = "30",
+            ["SporeSync:DownloadRetryMaxDelaySeconds"] = "10"
+        });
+
+        Assert.Throws<OptionsValidationException>(() => options.Value);
+    }
+
     private static IOptions<SporeSyncOptions> ResolveOptions(Dictionary<string, string?> settings)
     {
         var configuration = new ConfigurationBuilder()
@@ -73,7 +89,10 @@ public sealed class SporeSyncOptionsValidationTests
             .ValidateDataAnnotations()
             .Validate(
                 options => Path.IsPathFullyQualified(options.DestinationRootPath),
-                "DestinationRootPath must be an absolute path.");
+                "DestinationRootPath must be an absolute path.")
+            .Validate(
+                options => options.DownloadRetryMaxDelaySeconds >= options.DownloadRetryBaseDelaySeconds,
+                "DownloadRetryMaxDelaySeconds must not be below DownloadRetryBaseDelaySeconds.");
 
         return services.BuildServiceProvider().GetRequiredService<IOptions<SporeSyncOptions>>();
     }

--- a/SporeSync.Business.Tests/Worker/ChangeDetectorTests.cs
+++ b/SporeSync.Business.Tests/Worker/ChangeDetectorTests.cs
@@ -296,6 +296,34 @@ public sealed class ChangeDetectorTests
     }
 
     [Fact]
+    public void DetectChanges_UnchangedPermanentlyFailedGroup_OnLaterScanStaysDeadLettered()
+    {
+        var modifiedAt = DateTimeOffset.Parse("2026-05-28T12:00:00Z");
+        var detector = new ChangeDetector();
+        var group = new ScannedRemoteEntry("/remote/reports/", "/data/reports/", true, 100, 1, null, modifiedAt);
+        var leaf = new ScannedRemoteEntry(
+            "/remote/reports/unsafe.txt",
+            "/data/reports/unsafe.txt",
+            false,
+            100,
+            0,
+            group.RemotePath,
+            modifiedAt);
+        var scan = new FirstLevelScanResult([group], [leaf], 100, 1, 0);
+        var synced = new Dictionary<string, SyncedRemoteState>(StringComparer.Ordinal)
+        {
+            [group.RemotePath] = FailedState(group.RemotePath, modifiedAt, 100, childCount: 1),
+            [leaf.RemotePath] = FailedState(leaf.RemotePath, modifiedAt, 100)
+        };
+
+        var result = detector.DetectChanges(scan, synced);
+
+        Assert.Empty(result.EntriesToEnqueue);
+        Assert.Empty(result.EntriesToCarryForward);
+        Assert.Equal(0, result.EnqueuedVisibleCount);
+    }
+
+    [Fact]
     public void DetectChanges_UnchangedFailedEntry_StaysDeadLettered()
     {
         // A dead-lettered ('failed') item must not be auto-requeued while the remote file is
@@ -448,6 +476,20 @@ public sealed class ChangeDetectorTests
             ChildCount = childCount
         };
     }
+
+    private static SyncedRemoteState FailedState(
+        string remotePath,
+        DateTimeOffset? modifiedAt,
+        long fileSizeBytes,
+        int childCount = 0) =>
+        new()
+        {
+            RemotePath = remotePath,
+            RemoteModifiedAt = modifiedAt,
+            FileSizeBytes = fileSizeBytes,
+            Status = "failed",
+            ChildCount = childCount
+        };
 
     private static FirstLevelScanResult CreateScan(params ScannedRemoteEntry[] visible)
     {

--- a/SporeSync.Business.Tests/Worker/DownloadRetryPolicyTests.cs
+++ b/SporeSync.Business.Tests/Worker/DownloadRetryPolicyTests.cs
@@ -51,16 +51,30 @@ public sealed class DownloadRetryPolicyTests
         Assert.Equal(TimeSpan.FromSeconds(60), policy.GetRetryDelay(5));
     }
 
+    [Fact]
+    public void GetRetryDelay_WithJitter_StaysInsideConfiguredAndProportionalBounds()
+    {
+        var policy = CreatePolicy(baseDelaySeconds: 10, maxDelaySeconds: 100, jitterRatio: 0.25);
+
+        for (var sample = 0; sample < 100; sample++)
+        {
+            var delay = policy.GetRetryDelay(2);
+            Assert.InRange(delay, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(50));
+        }
+    }
+
     private static DownloadRetryPolicy CreatePolicy(
         int maxRetries = 3,
         int baseDelaySeconds = 30,
-        int maxDelaySeconds = 900)
+        int maxDelaySeconds = 900,
+        double jitterRatio = 0)
     {
         return new DownloadRetryPolicy(Options.Create(new SporeSyncOptions
         {
             DownloadMaxRetries = maxRetries,
             DownloadRetryBaseDelaySeconds = baseDelaySeconds,
-            DownloadRetryMaxDelaySeconds = maxDelaySeconds
+            DownloadRetryMaxDelaySeconds = maxDelaySeconds,
+            DownloadRetryJitterRatio = jitterRatio
         }));
     }
 }

--- a/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
@@ -78,6 +78,42 @@ public sealed class DownloadWorkerHostedServiceTests
     }
 
     [Fact]
+    public async Task ProcessNextItem_PermanentFailure_FailsWithoutSchedulingRetry()
+    {
+        var item = CreateItem("/remote/file.txt");
+        var queueRepository = new FakeQueueRepository(item);
+        var downloader = new FakeDownloader(_ => SftpDownloadResult.PermanentFailure("unsafe destination"));
+        var worker = CreateWorker(queueRepository, downloader);
+
+        await worker.ProcessNextItemAsync(CancellationToken.None);
+
+        Assert.Empty(queueRepository.FailureCalls);
+        var update = Assert.Single(queueRepository.ProgressUpdates);
+        Assert.Equal("failed", update.Status);
+        Assert.Equal("permanent_error", update.HandledReason);
+        Assert.Equal("unsafe destination", update.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task StopAsync_CancelsPollWhileRetryRemainsScheduled()
+    {
+        var item = CreateItem("/remote/file.txt");
+        var queueRepository = new FakeQueueRepository(item);
+        var downloader = new FakeDownloader(_ => SftpDownloadResult.Failure("connection reset"));
+        var worker = CreateWorker(queueRepository, downloader);
+
+        await worker.StartAsync(CancellationToken.None);
+        for (var attempt = 0; attempt < 100 && queueRepository.FailureCalls.Count == 0; attempt++)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.Single(queueRepository.FailureCalls);
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+        await worker.StopAsync(timeout.Token);
+    }
+
+    [Fact]
     public async Task ProcessNextItem_GroupWithFailedLeaf_MarksLeafFailedAndRecordsGroupFailure()
     {
         var group = CreateItem("/remote/reports/", isGroup: true, childCount: 2);
@@ -107,6 +143,23 @@ public sealed class DownloadWorkerHostedServiceTests
         Assert.Equal(group.Id, failure.Id);
         // Completed-leaf bytes are preserved on the group row while it awaits retry.
         Assert.Equal(100, failure.BytesDownloaded);
+    }
+
+    [Fact]
+    public async Task ProcessNextItem_GroupWithPermanentLeafFailure_FailsGroupWithoutRetry()
+    {
+        var group = CreateItem("/remote/reports/", isGroup: true, childCount: 1);
+        var leaf = CreateItem("/remote/reports/unsafe.txt", groupRemotePath: group.RemotePath);
+        var queueRepository = new FakeQueueRepository(group) { Leaves = [leaf] };
+        var downloader = new FakeDownloader(_ => SftpDownloadResult.PermanentFailure("unsafe destination"));
+        var worker = CreateWorker(queueRepository, downloader);
+
+        await worker.ProcessNextItemAsync(CancellationToken.None);
+
+        Assert.Empty(queueRepository.FailureCalls);
+        var groupUpdate = queueRepository.ProgressUpdates.Single(update => update.Id == group.Id);
+        Assert.Equal("failed", groupUpdate.Status);
+        Assert.Equal("permanent_error", groupUpdate.HandledReason);
     }
 
     [Fact]
@@ -238,8 +291,10 @@ public sealed class DownloadWorkerHostedServiceTests
     {
         var options = Options.Create(new SporeSyncOptions
         {
+            DownloadPollIntervalMs = 600_000,
             DownloadMaxRetries = maxRetries,
             DownloadRetryBaseDelaySeconds = baseDelaySeconds,
+            DownloadRetryJitterRatio = 0,
             RemoteFileStabilityWindowSeconds = stabilityWindowSeconds
         });
 

--- a/SporeSync.Business/ServiceExtension.cs
+++ b/SporeSync.Business/ServiceExtension.cs
@@ -21,6 +21,9 @@ public static class ServiceExtension
             .Validate(
                 options => Path.IsPathFullyQualified(options.DestinationRootPath),
                 $"{SporeSyncOptions.SectionName}:{nameof(SporeSyncOptions.DestinationRootPath)} must be an absolute path.")
+            .Validate(
+                options => options.DownloadRetryMaxDelaySeconds >= options.DownloadRetryBaseDelaySeconds,
+                $"{SporeSyncOptions.SectionName}:{nameof(SporeSyncOptions.DownloadRetryMaxDelaySeconds)} must be greater than or equal to {nameof(SporeSyncOptions.DownloadRetryBaseDelaySeconds)}.")
             .ValidateOnStart();
         services.AddSingleton<SporeSyncMetrics>();
         services.AddSingleton<IEncryptionKeyProvider, EncryptionKeyProvider>();

--- a/SporeSync.Business/Sftp/SftpFileDownloader.cs
+++ b/SporeSync.Business/Sftp/SftpFileDownloader.cs
@@ -121,7 +121,7 @@ public sealed class SftpFileDownloader : ISftpFileDownloader
                 "Refusing to download {RemotePath} to unsafe local path {LocalPath}",
                 remotePath,
                 localPath);
-            failure = SftpDownloadResult.Failure(ex.Message);
+            failure = SftpDownloadResult.PermanentFailure(ex.Message);
             return false;
         }
     }
@@ -347,14 +347,24 @@ public sealed record SftpDownloadResult(
     long BytesDownloaded,
     decimal? BytesPerSecond,
     string? ErrorMessage,
-    bool Deferred = false)
+    bool Deferred = false,
+    DownloadFailureKind FailureKind = DownloadFailureKind.Transient)
 {
     public static SftpDownloadResult Succeed(long bytesDownloaded, decimal? bytesPerSecond) =>
         new(true, bytesDownloaded, bytesPerSecond, null);
 
     public static SftpDownloadResult Failure(string? errorMessage) =>
-        new(false, 0, null, errorMessage);
+        new(false, 0, null, errorMessage, FailureKind: DownloadFailureKind.Transient);
+
+    public static SftpDownloadResult PermanentFailure(string? errorMessage) =>
+        new(false, 0, null, errorMessage, FailureKind: DownloadFailureKind.Permanent);
 
     public static SftpDownloadResult Defer(string reason) =>
         new(false, 0, null, reason, Deferred: true);
+}
+
+public enum DownloadFailureKind
+{
+    Transient,
+    Permanent
 }

--- a/SporeSync.Business/SporeSyncOptions.cs
+++ b/SporeSync.Business/SporeSyncOptions.cs
@@ -48,13 +48,20 @@ public sealed class SporeSyncOptions
     /// Number of retries allowed for a queue item after its initial download attempt.
     /// Once exhausted the item is dead-lettered as terminal 'failed'.
     /// </summary>
+    [Range(0, 100)]
     public int DownloadMaxRetries { get; set; } = 3;
 
     /// <summary>Base delay for the exponential retry backoff (base * 2^retryCount).</summary>
+    [Range(1, 86_400)]
     public int DownloadRetryBaseDelaySeconds { get; set; } = 30;
 
     /// <summary>Upper bound for the exponential retry backoff delay.</summary>
+    [Range(1, 86_400)]
     public int DownloadRetryMaxDelaySeconds { get; set; } = 900;
+
+    /// <summary>Maximum proportional jitter applied above or below each exponential delay.</summary>
+    [Range(typeof(double), "0", "1")]
+    public double DownloadRetryJitterRatio { get; set; } = 0.2;
 
     /// <summary>
     /// A remote file whose modification time is within this window is considered still

--- a/SporeSync.Business/Worker/ChangeDetector.cs
+++ b/SporeSync.Business/Worker/ChangeDetector.cs
@@ -132,7 +132,8 @@ public sealed class ChangeDetector : IChangeDetector
             return true;
         }
 
-        if (!IsCompleted(existing.Status))
+        if (!IsCompleted(existing.Status)
+            && !string.Equals(existing.Status, "failed", StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }

--- a/SporeSync.Business/Worker/DownloadRetryPolicy.cs
+++ b/SporeSync.Business/Worker/DownloadRetryPolicy.cs
@@ -22,18 +22,22 @@ public sealed class DownloadRetryPolicy
         TimeSpan.FromSeconds(Math.Max(1, _options.RemoteFileStabilityWindowSeconds));
 
     /// <summary>
-    /// Exponential backoff delay for the next attempt given how many attempts have already failed:
-    /// base * 2^failedAttempts, capped at the configured maximum.
+    /// Exponential backoff delay for the next attempt given how many attempts have already failed.
+    /// Symmetric jitter is applied to base * 2^failedAttempts, then the result is clamped to the
+    /// configured minimum and maximum delay bounds.
     /// </summary>
     public TimeSpan GetRetryDelay(int failedAttempts)
     {
-        var baseDelaySeconds = Math.Max(1, _options.DownloadRetryBaseDelaySeconds);
-        var maxDelaySeconds = Math.Max(baseDelaySeconds, _options.DownloadRetryMaxDelaySeconds);
+        var minDelaySeconds = Math.Max(1, _options.DownloadRetryBaseDelaySeconds);
+        var maxDelaySeconds = Math.Max(minDelaySeconds, _options.DownloadRetryMaxDelaySeconds);
 
         // Clamp the exponent so the double cannot overflow for pathological retry counts.
         var exponent = Math.Clamp(failedAttempts, 0, 30);
-        var delaySeconds = baseDelaySeconds * Math.Pow(2, exponent);
+        var exponentialSeconds = Math.Min(minDelaySeconds * Math.Pow(2, exponent), maxDelaySeconds);
+        var jitterRatio = Math.Clamp(_options.DownloadRetryJitterRatio, 0, 1);
+        var jitterMultiplier = 1 + ((Random.Shared.NextDouble() * 2 - 1) * jitterRatio);
+        var delaySeconds = exponentialSeconds * jitterMultiplier;
 
-        return TimeSpan.FromSeconds(Math.Min(delaySeconds, maxDelaySeconds));
+        return TimeSpan.FromSeconds(Math.Clamp(delaySeconds, minDelaySeconds, maxDelaySeconds));
     }
 }

--- a/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
+++ b/SporeSync.Business/Worker/DownloadWorkerHostedService.cs
@@ -267,12 +267,9 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                 token));
         }
 
-        return await progress.CompleteAsync(token => RecordFailureAsync(
-            queueRepository,
-            item,
-            result.ErrorMessage,
-            bytesDownloaded: null,
-            token));
+        return await progress.CompleteAsync(token => result.FailureKind == DownloadFailureKind.Permanent
+            ? RecordPermanentFailureAsync(queueRepository, item, result.ErrorMessage, bytesDownloaded: null, token)
+            : RecordFailureAsync(queueRepository, item, result.ErrorMessage, bytesDownloaded: null, token));
     }
 
     private async Task<DownloadQueueItem> ProcessGroupAsync(
@@ -293,6 +290,7 @@ public sealed class DownloadWorkerHostedService : BackgroundService
         long groupBytesDownloaded = 0;
         decimal? latestRate = null;
         var groupFailed = false;
+        var groupPermanentFailure = false;
         var groupDeferred = false;
 
         IConnectedSftpClient? connection = null;
@@ -465,6 +463,7 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                 }, token));
 
                 groupFailed = true;
+                groupPermanentFailure |= leafResult.FailureKind == DownloadFailureKind.Permanent;
                 if (connection is not null)
                 {
                     await connection.DisposeAsync();
@@ -487,6 +486,16 @@ public sealed class DownloadWorkerHostedService : BackgroundService
 
         if (groupFailed)
         {
+            if (groupPermanentFailure)
+            {
+                return await RecordPermanentFailureAsync(
+                    queueRepository,
+                    groupItem,
+                    "One or more files in the group have a permanent download error.",
+                    groupBytesDownloaded,
+                    cancellationToken);
+            }
+
             // The group carries the retry budget for its subtree: failed leaves are retried on the
             // group's next claim (only non-completed leaves are re-attempted) until the budget is
             // exhausted, at which point the group is dead-lettered as terminal 'failed'.
@@ -682,6 +691,32 @@ public sealed class DownloadWorkerHostedService : BackgroundService
                 nextAttemptAt,
                 errorMessage);
         }
+
+        return updated;
+    }
+
+    private async Task<DownloadQueueItem> RecordPermanentFailureAsync(
+        IDownloadQueueItemRepository queueRepository,
+        DownloadQueueItem item,
+        string? errorMessage,
+        long? bytesDownloaded,
+        CancellationToken cancellationToken)
+    {
+        var updated = await queueRepository.UpdateProgressAsync(new UpdateDownloadQueueItemProgress
+        {
+            Id = item.Id,
+            Status = "failed",
+            BytesDownloaded = bytesDownloaded ?? item.BytesDownloaded,
+            CurrentBytesPerSecond = null,
+            ErrorMessage = errorMessage,
+            HandledReason = "permanent_error"
+        }, cancellationToken);
+
+        _logger.LogWarning(
+            "Queue item {QueueItemId} ({RemotePath}) failed permanently and will not be retried: {Error}",
+            updated.Id,
+            updated.RemotePath,
+            errorMessage);
 
         return updated;
     }

--- a/SporeSync.Web/appsettings.json
+++ b/SporeSync.Web/appsettings.json
@@ -23,6 +23,10 @@
     "DownloadLeaseSeconds": 300,
     "RunScanLeaseSeconds": 1800,
     "RecoverySweepIntervalSeconds": 60,
+    "DownloadMaxRetries": 3,
+    "DownloadRetryBaseDelaySeconds": 30,
+    "DownloadRetryMaxDelaySeconds": 900,
+    "DownloadRetryJitterRatio": 0.2,
     "RunHistoryRetentionDays": 30,
     "RetentionSweepIntervalHours": 6
   },


### PR DESCRIPTION
Closes #22

## Summary
- add validated retry attempt, delay, and jitter configuration with bounded exponential scheduling
- classify unsafe destination failures as permanent while retrying transient connection/transfer failures in the same run
- keep retry backoff durable and non-blocking, preserve dashboard retry counts, and surface clear terminal reasons
- document retry configuration and error classification
- cover eventual success, exhaustion, permanent failures, unrelated queue work, and shutdown cancellation

## Validation
- `dotnet build SporeSync.sln` — passed (existing warnings remain)
- `dotnet test SporeSync.sln` — passed: 270 tests
- Frontend checks not run; no UI files changed