### PR TITLE
Allow SFTP authentication methods to be replaced or cleared

### DIFF
--- a/SporeSync.Business.Tests/SftpConnectionProfileServiceTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfileServiceTests.cs
@@ -9,7 +9,7 @@ namespace SporeSync.Business.Tests;
 public sealed class SftpConnectionProfileServiceTests
 {
     [Fact]
-    public async Task UpsertAsync_Throws_WhenPasswordAndPrivateKeyAreMissing()
+    public async Task UpsertAsync_Throws_WhenSelectedPasswordIsMissing()
     {
         var repository = new RecordingSftpConnectionProfileRepository();
         var secretProtector = new RecordingSecretProtector();
@@ -25,13 +25,13 @@ public sealed class SftpConnectionProfileServiceTests
         var exception = await Assert.ThrowsAsync<ValidationException>(
             () => service.UpsertAsync(profile));
 
-        Assert.Equal("An SFTP password or private key is required.", exception.Message);
+        Assert.Equal("A password is required for password authentication.", exception.Message);
         Assert.Null(repository.LastUpsertedProfile);
         Assert.Empty(secretProtector.ProtectedValues);
     }
 
     [Fact]
-    public async Task UpsertAsync_ProtectsSecretsAndPersistsProfile()
+    public async Task UpsertAsync_ProtectsPrivateKeySecretsAndPersistsProfile()
     {
         var repository = new RecordingSftpConnectionProfileRepository();
         var secretProtector = new RecordingSecretProtector();
@@ -46,7 +46,7 @@ public sealed class SftpConnectionProfileServiceTests
                 Host = "sftp.example.com",
                 Port = 2222,
                 Username = "sync-user",
-                Password = "password-1",
+                AuthenticationMethod = SftpAuthenticationMethod.PrivateKey,
                 PrivateKey = "private-key",
                 PrivateKeyPassphrase = "passphrase",
                 IsDefault = false
@@ -59,11 +59,11 @@ public sealed class SftpConnectionProfileServiceTests
         Assert.Equal("sftp.example.com", repository.LastUpsertedProfile.Host);
         Assert.Equal(2222, repository.LastUpsertedProfile.Port);
         Assert.Equal("sync-user", repository.LastUpsertedProfile.Username);
-        Assert.Equal("protected:password-1", repository.LastUpsertedProfile.EncryptedPassword);
+        Assert.Null(repository.LastUpsertedProfile.EncryptedPassword);
         Assert.Equal("protected:private-key", repository.LastUpsertedProfile.EncryptedPrivateKey);
         Assert.Equal("protected:passphrase", repository.LastUpsertedProfile.EncryptedPrivateKeyPassphrase);
         Assert.False(repository.LastUpsertedProfile.IsDefault);
-        Assert.Equal(["password-1", "private-key", "passphrase"], secretProtector.ProtectedValues);
+        Assert.Equal(["private-key", "passphrase"], secretProtector.ProtectedValues);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public sealed class SftpConnectionProfileServiceTests
     }
 
     [Fact]
-    public async Task UpsertAsync_PreservesExistingSecrets_WhenEditingWithoutReplacement()
+    public async Task UpsertAsync_PreservesExistingPassword_WhenEditingWithoutReplacement()
     {
         var profileId = Guid.NewGuid();
         var repository = new RecordingSftpConnectionProfileRepository
@@ -105,8 +105,6 @@ public sealed class SftpConnectionProfileServiceTests
                 Port = 22,
                 Username = "old-user",
                 EncryptedPassword = "existing-password",
-                EncryptedPrivateKey = "existing-key",
-                EncryptedPrivateKeyPassphrase = "existing-passphrase",
                 IsDefault = true
             }
         };
@@ -122,16 +120,130 @@ public sealed class SftpConnectionProfileServiceTests
                 Port = 2222,
                 Username = "new-user",
                 Password = "",
-                PrivateKey = " ",
-                PrivateKeyPassphrase = null,
                 IsDefault = false
             });
 
         Assert.NotNull(repository.LastUpsertedProfile);
         Assert.Equal("existing-password", repository.LastUpsertedProfile.EncryptedPassword);
+        Assert.Null(repository.LastUpsertedProfile.EncryptedPrivateKey);
+        Assert.Null(repository.LastUpsertedProfile.EncryptedPrivateKeyPassphrase);
+        Assert.Empty(secretProtector.ProtectedValues);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_SwitchesPrivateKeyToPassword_AndClearsIncompatibleSecrets()
+    {
+        var profileId = Guid.NewGuid();
+        var repository = RepositoryWithProfile(profileId, password: null, privateKey: "existing-key", passphrase: "existing-passphrase");
+        var protector = new RecordingSecretProtector();
+
+        await CreateService(repository, protector).UpsertAsync(new UpsertSftpConnectionProfile
+        {
+            Id = profileId,
+            Name = "updated",
+            Host = "sftp.example.com",
+            Username = "sync-user",
+            AuthenticationMethod = SftpAuthenticationMethod.Password,
+            Password = "new-password"
+        });
+
+        Assert.NotNull(repository.LastUpsertedProfile);
+        Assert.Equal("protected:new-password", repository.LastUpsertedProfile.EncryptedPassword);
+        Assert.Null(repository.LastUpsertedProfile.EncryptedPrivateKey);
+        Assert.Null(repository.LastUpsertedProfile.EncryptedPrivateKeyPassphrase);
+        Assert.Equal(["new-password"], protector.ProtectedValues);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_SwitchesPasswordToPrivateKey_AndClearsPassword()
+    {
+        var profileId = Guid.NewGuid();
+        var repository = RepositoryWithProfile(profileId, password: "existing-password", privateKey: null);
+        var protector = new RecordingSecretProtector();
+
+        await CreateService(repository, protector).UpsertAsync(new UpsertSftpConnectionProfile
+        {
+            Id = profileId,
+            Name = "updated",
+            Host = "sftp.example.com",
+            Username = "sync-user",
+            AuthenticationMethod = SftpAuthenticationMethod.PrivateKey,
+            PrivateKey = "new-key",
+            PrivateKeyPassphrase = "new-passphrase"
+        });
+
+        Assert.NotNull(repository.LastUpsertedProfile);
+        Assert.Null(repository.LastUpsertedProfile.EncryptedPassword);
+        Assert.Equal("protected:new-key", repository.LastUpsertedProfile.EncryptedPrivateKey);
+        Assert.Equal("protected:new-passphrase", repository.LastUpsertedProfile.EncryptedPrivateKeyPassphrase);
+        Assert.Equal(["new-key", "new-passphrase"], protector.ProtectedValues);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_PreservesPrivateKeyAndPassphrase_WhenReplacementInputsAreBlank()
+    {
+        var profileId = Guid.NewGuid();
+        var repository = RepositoryWithProfile(profileId, password: null, privateKey: "existing-key", passphrase: "existing-passphrase");
+        var protector = new RecordingSecretProtector();
+
+        await CreateService(repository, protector).UpsertAsync(new UpsertSftpConnectionProfile
+        {
+            Id = profileId,
+            Name = "updated",
+            Host = "sftp.example.com",
+            Username = "sync-user",
+            AuthenticationMethod = SftpAuthenticationMethod.PrivateKey,
+            PrivateKey = " ",
+            PrivateKeyPassphrase = ""
+        });
+
+        Assert.NotNull(repository.LastUpsertedProfile);
+        Assert.Null(repository.LastUpsertedProfile.EncryptedPassword);
         Assert.Equal("existing-key", repository.LastUpsertedProfile.EncryptedPrivateKey);
         Assert.Equal("existing-passphrase", repository.LastUpsertedProfile.EncryptedPrivateKeyPassphrase);
-        Assert.Empty(secretProtector.ProtectedValues);
+        Assert.Empty(protector.ProtectedValues);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_RemovesPrivateKeyPassphrase_WhenExplicitlyRequested()
+    {
+        var profileId = Guid.NewGuid();
+        var repository = RepositoryWithProfile(profileId, password: null, privateKey: "existing-key", passphrase: "existing-passphrase");
+
+        await CreateService(repository, new RecordingSecretProtector()).UpsertAsync(new UpsertSftpConnectionProfile
+        {
+            Id = profileId,
+            Name = "updated",
+            Host = "sftp.example.com",
+            Username = "sync-user",
+            AuthenticationMethod = SftpAuthenticationMethod.PrivateKey,
+            RemovePrivateKeyPassphrase = true
+        });
+
+        Assert.NotNull(repository.LastUpsertedProfile);
+        Assert.Equal("existing-key", repository.LastUpsertedProfile.EncryptedPrivateKey);
+        Assert.Null(repository.LastUpsertedProfile.EncryptedPrivateKeyPassphrase);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_DoesNotClearExistingCredential_WhenReplacementForNewMethodIsBlank()
+    {
+        var profileId = Guid.NewGuid();
+        var repository = RepositoryWithProfile(profileId, password: null, privateKey: "existing-key");
+
+        var exception = await Assert.ThrowsAsync<ValidationException>(() =>
+            CreateService(repository, new RecordingSecretProtector()).UpsertAsync(new UpsertSftpConnectionProfile
+            {
+                Id = profileId,
+                Name = "updated",
+                Host = "sftp.example.com",
+                Username = "sync-user",
+                AuthenticationMethod = SftpAuthenticationMethod.Password,
+                Password = " "
+            }));
+
+        Assert.Equal("A password is required for password authentication.", exception.Message);
+        Assert.Null(repository.LastUpsertedProfile);
     }
 
     [Fact]
@@ -287,6 +399,29 @@ public sealed class SftpConnectionProfileServiceTests
 
         Assert.Equal(DeleteSftpConnectionProfileStatus.Deleted, status);
         Assert.Equal(profileId, repository.DeletedId);
+    }
+
+    private static RecordingSftpConnectionProfileRepository RepositoryWithProfile(
+        Guid id,
+        string? password,
+        string? privateKey,
+        string? passphrase = null)
+    {
+        return new RecordingSftpConnectionProfileRepository
+        {
+            ProfileById = new SftpConnectionProfile
+            {
+                Id = id,
+                Name = "existing",
+                Host = "sftp.example.com",
+                Port = 22,
+                Username = "sync-user",
+                EncryptedPassword = password,
+                EncryptedPrivateKey = privateKey,
+                EncryptedPrivateKeyPassphrase = passphrase,
+                IsDefault = true
+            }
+        };
     }
 
     private static SftpConnectionProfileService CreateService(

--- a/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
@@ -10,6 +10,32 @@ namespace SporeSync.Business.Tests;
 
 public sealed class SftpConnectionProfilesControllerTests
 {
+    [Theory]
+    [InlineData("password", SftpAuthenticationMethod.Password, false)]
+    [InlineData("privateKey", SftpAuthenticationMethod.PrivateKey, true)]
+    public async Task Update_ForwardsExplicitAuthenticationTransition(
+        string authenticationMethod,
+        SftpAuthenticationMethod expectedMethod,
+        bool removePassphrase)
+    {
+        var service = new FakeProfileService();
+        var controller = CreateController(profileService: service);
+        var id = Guid.NewGuid();
+
+        await controller.Update(
+            id,
+            CreateRequest(authenticationMethod, removePassphrase),
+            CancellationToken.None);
+
+        Assert.NotNull(service.LastUpsert);
+        Assert.Equal(id, service.LastUpsert.Id);
+        Assert.Equal(expectedMethod, service.LastUpsert.AuthenticationMethod);
+        Assert.Equal("replacement-password", service.LastUpsert.Password);
+        Assert.Equal("replacement-key", service.LastUpsert.PrivateKey);
+        Assert.Equal("replacement-passphrase", service.LastUpsert.PrivateKeyPassphrase);
+        Assert.Equal(removePassphrase, service.LastUpsert.RemovePrivateKeyPassphrase);
+    }
+
     [Fact]
     public async Task Test_ReturnsNotFound_WhenProfileDoesNotExist()
     {
@@ -83,15 +109,32 @@ public sealed class SftpConnectionProfilesControllerTests
 
     private static SftpConnectionProfilesController CreateController(
         SftpConnectionTestResult? testResult = null,
-        DeleteSftpConnectionProfileStatus deleteStatus = DeleteSftpConnectionProfileStatus.Deleted)
+        DeleteSftpConnectionProfileStatus deleteStatus = DeleteSftpConnectionProfileStatus.Deleted,
+        FakeProfileService? profileService = null)
     {
         return new SftpConnectionProfilesController(
-            new FakeProfileService { DeleteStatus = deleteStatus },
+            profileService ?? new FakeProfileService { DeleteStatus = deleteStatus },
             new FakeHostKeyScanner(),
             new FakeConnectionTestService
             {
                 Result = testResult ?? new SftpConnectionTestResult { ProfileFound = false }
             });
+    }
+
+    private static UpsertSftpConnectionProfileRequest CreateRequest(
+        string authenticationMethod,
+        bool removePassphrase)
+    {
+        return new UpsertSftpConnectionProfileRequest(
+            "profile",
+            "sftp.example.com",
+            22,
+            "sync-user",
+            authenticationMethod,
+            "replacement-password",
+            "replacement-key",
+            "replacement-passphrase",
+            removePassphrase);
     }
 
     private sealed class FakeHostKeyScanner : ISshHostKeyScanner
@@ -112,6 +155,8 @@ public sealed class SftpConnectionProfilesControllerTests
     {
         public DeleteSftpConnectionProfileStatus DeleteStatus { get; init; }
 
+        public UpsertSftpConnectionProfile? LastUpsert { get; private set; }
+
         public Task<DeleteSftpConnectionProfileStatus> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
             => Task.FromResult(DeleteStatus);
 
@@ -122,6 +167,23 @@ public sealed class SftpConnectionProfilesControllerTests
             => throw new NotSupportedException();
 
         public Task<SftpConnectionProfile> UpsertAsync(UpsertSftpConnectionProfile profile, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+        {
+            LastUpsert = profile;
+            return Task.FromResult(new SftpConnectionProfile
+            {
+                Id = profile.Id ?? Guid.NewGuid(),
+                Name = profile.Name,
+                Host = profile.Host,
+                Port = profile.Port,
+                Username = profile.Username,
+                EncryptedPassword = profile.AuthenticationMethod == SftpAuthenticationMethod.Password
+                    ? "encrypted-password"
+                    : null,
+                EncryptedPrivateKey = profile.AuthenticationMethod == SftpAuthenticationMethod.PrivateKey
+                    ? "encrypted-key"
+                    : null,
+                IsDefault = profile.IsDefault
+            });
+        }
     }
 }

--- a/SporeSync.Business/Service/SftpConnectionProfileService.cs
+++ b/SporeSync.Business/Service/SftpConnectionProfileService.cs
@@ -45,15 +45,8 @@ public sealed class SftpConnectionProfileService : ISftpConnectionProfileService
             existingProfile = await _repository.GetByIdAsync(id, cancellationToken);
         }
 
-        var encryptedPassword = ProtectOptional(profile.Password) ?? existingProfile?.EncryptedPassword;
-        var encryptedPrivateKey = ProtectOptional(profile.PrivateKey) ?? existingProfile?.EncryptedPrivateKey;
-        var encryptedPrivateKeyPassphrase = ProtectOptional(profile.PrivateKeyPassphrase)
-            ?? existingProfile?.EncryptedPrivateKeyPassphrase;
-
-        if (string.IsNullOrWhiteSpace(encryptedPassword) && string.IsNullOrWhiteSpace(encryptedPrivateKey))
-        {
-            throw new ValidationException("An SFTP password or private key is required.");
-        }
+        var (encryptedPassword, encryptedPrivateKey, encryptedPrivateKeyPassphrase) =
+            ResolveAuthentication(profile, existingProfile);
 
         var protectedProfile = new SftpConnectionProfile
         {
@@ -72,6 +65,39 @@ public sealed class SftpConnectionProfileService : ISftpConnectionProfileService
         };
 
         return await _repository.UpsertAsync(protectedProfile, cancellationToken);
+    }
+
+    private (string? Password, string? PrivateKey, string? Passphrase) ResolveAuthentication(
+        UpsertSftpConnectionProfile requested,
+        SftpConnectionProfile? existing)
+    {
+        if (requested.AuthenticationMethod == SftpAuthenticationMethod.Password)
+        {
+            var password = ProtectOptional(requested.Password) ?? existing?.EncryptedPassword;
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ValidationException("A password is required for password authentication.");
+            }
+
+            return (password, null, null);
+        }
+
+        if (requested.AuthenticationMethod != SftpAuthenticationMethod.PrivateKey)
+        {
+            throw new ValidationException("A supported SFTP authentication method is required.");
+        }
+
+        var privateKey = ProtectOptional(requested.PrivateKey) ?? existing?.EncryptedPrivateKey;
+        if (string.IsNullOrWhiteSpace(privateKey))
+        {
+            throw new ValidationException("A private key is required for private key authentication.");
+        }
+
+        var passphrase = requested.RemovePrivateKeyPassphrase
+            ? null
+            : ProtectOptional(requested.PrivateKeyPassphrase) ?? existing?.EncryptedPrivateKeyPassphrase;
+
+        return (null, privateKey, passphrase);
     }
 
     private static string? ResolveHostKeyFingerprint(string? requested, string? existing)

--- a/SporeSync.Domain/Model/SftpAuthenticationMethod.cs
+++ b/SporeSync.Domain/Model/SftpAuthenticationMethod.cs
@@ -1,0 +1,7 @@
+namespace SporeSync.Domain.Model;
+
+public enum SftpAuthenticationMethod
+{
+    Password,
+    PrivateKey
+}

--- a/SporeSync.Domain/Model/UpsertSftpConnectionProfile.cs
+++ b/SporeSync.Domain/Model/UpsertSftpConnectionProfile.cs
@@ -12,11 +12,22 @@ public sealed class UpsertSftpConnectionProfile
 
     public required string Username { get; init; }
 
+    /// <summary>
+    /// Selects the only credential type that will remain stored after this upsert.
+    /// </summary>
+    public SftpAuthenticationMethod AuthenticationMethod { get; init; }
+
     public string? Password { get; init; }
 
     public string? PrivateKey { get; init; }
 
     public string? PrivateKeyPassphrase { get; init; }
+
+    /// <summary>
+    /// Explicitly clears a stored private key passphrase. When false, a blank
+    /// replacement preserves the existing passphrase.
+    /// </summary>
+    public bool RemovePrivateKeyPassphrase { get; init; }
 
     /// <summary>
     /// SSH host key fingerprint to pin. Null preserves the currently stored fingerprint,

--- a/SporeSync.Web/ClientApp/src/api/types.ts
+++ b/SporeSync.Web/ClientApp/src/api/types.ts
@@ -79,6 +79,7 @@ export interface SftpConnectionProfile {
   host: string;
   port: number;
   username: string;
+  authenticationMethod: "password" | "privateKey";
   hasPassword: boolean;
   hasPrivateKey: boolean;
   hasPrivateKeyPassphrase: boolean;
@@ -91,9 +92,11 @@ export interface UpsertSftpConnectionProfile {
   host: string;
   port: number;
   username: string;
+  authenticationMethod: "password" | "privateKey";
   password?: string | null;
   privateKey?: string | null;
   privateKeyPassphrase?: string | null;
+  removePrivateKeyPassphrase: boolean;
   // Null preserves the stored pin; an empty string clears it (trust-on-first-use).
   hostKeyFingerprintSha256?: string | null;
   isDefault: boolean;

--- a/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
@@ -819,16 +819,20 @@ function ProfileForm({
   const [host, setHost] = useState(profile?.host ?? "");
   const [port, setPort] = useState(profile?.port ?? 22);
   const [username, setUsername] = useState(profile?.username ?? "");
+  const [authenticationMethod, setAuthenticationMethod] = useState<
+    "password" | "privateKey"
+  >(profile?.authenticationMethod ?? "password");
   const [password, setPassword] = useState("");
   const [privateKey, setPrivateKey] = useState("");
   const [privateKeyPassphrase, setPrivateKeyPassphrase] = useState("");
+  const [removePrivateKeyPassphrase, setRemovePrivateKeyPassphrase] =
+    useState(false);
   const [hostKeyFingerprint, setHostKeyFingerprint] = useState(
     profile?.hostKeyFingerprintSha256 ?? "",
   );
   const [isDefault, setIsDefault] = useState(profile?.isDefault ?? true);
-  const hasExistingSecret = Boolean(
-    profile?.hasPassword || profile?.hasPrivateKey,
-  );
+  const preservesSelectedCredential =
+    profile?.authenticationMethod === authenticationMethod;
   const scanMutation = useMutation({
     mutationFn: () => api.scanHostKey(host.trim(), port),
     onSuccess: (result) => {
@@ -840,10 +844,29 @@ function ProfileForm({
     if (!host.trim()) return "Host is required.";
     if (port < 1 || port > 65535) return "Port must be between 1 and 65535.";
     if (!username.trim()) return "Username is required.";
-    if (!hasExistingSecret && !password.trim() && !privateKey.trim())
-      return "Password or private key is required.";
+    if (
+      authenticationMethod === "password" &&
+      !preservesSelectedCredential &&
+      !password.trim()
+    )
+      return "Password is required when selecting password authentication.";
+    if (
+      authenticationMethod === "privateKey" &&
+      !preservesSelectedCredential &&
+      !privateKey.trim()
+    )
+      return "Private key is required when selecting key authentication.";
     return undefined;
-  }, [hasExistingSecret, host, name, password, port, privateKey, username]);
+  }, [
+    authenticationMethod,
+    host,
+    name,
+    password,
+    port,
+    preservesSelectedCredential,
+    privateKey,
+    username,
+  ]);
 
   return (
     <form
@@ -856,11 +879,13 @@ function ProfileForm({
             host,
             port,
             username,
+            authenticationMethod,
             password: password.trim() ? password : null,
             privateKey: privateKey.trim() ? privateKey : null,
             privateKeyPassphrase: privateKeyPassphrase.trim()
               ? privateKeyPassphrase
               : null,
+            removePrivateKeyPassphrase,
             // The form always knows the current pin, so submit it verbatim;
             // an empty value clears the pin and re-enables trust-on-first-use.
             hostKeyFingerprintSha256: hostKeyFingerprint.trim(),
@@ -905,37 +930,107 @@ function ProfileForm({
             onChange={(event) => setUsername(event.target.value)}
           />
         </Field>
-        <Field label={profile?.hasPassword ? "Replace password" : "Password"}>
-          <input
+        <Field label="Authentication method">
+          <select
             className={inputClass}
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-          />
+            value={authenticationMethod}
+            onChange={(event) => {
+              setAuthenticationMethod(
+                event.target.value as "password" | "privateKey",
+              );
+              setRemovePrivateKeyPassphrase(false);
+            }}
+          >
+            <option value="password">Password</option>
+            <option value="privateKey">Private key</option>
+          </select>
         </Field>
-        <Field
-          label={profile?.hasPrivateKey ? "Replace private key" : "Private key"}
-        >
-          <textarea
-            className={`${inputClass} min-h-24 py-2 font-mono text-xs`}
-            value={privateKey}
-            onChange={(event) => setPrivateKey(event.target.value)}
-          />
-        </Field>
-        <Field
-          label={
-            profile?.hasPrivateKeyPassphrase
-              ? "Replace key passphrase"
-              : "Key passphrase"
-          }
-        >
-          <input
-            className={inputClass}
-            type="password"
-            value={privateKeyPassphrase}
-            onChange={(event) => setPrivateKeyPassphrase(event.target.value)}
-          />
-        </Field>
+        <div className="hidden md:block" />
+        {authenticationMethod === "password" ? (
+          <div className="md:col-span-2">
+            <Field
+              label={
+                preservesSelectedCredential ? "Replace password" : "Password"
+              }
+            >
+              <input
+                className={inputClass}
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </Field>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {preservesSelectedCredential
+                ? "Leave blank to keep the stored password. Enter a value to replace it."
+                : "A password is required. Saving removes any stored private key and passphrase."}
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="md:col-span-2">
+              <Field
+                label={
+                  preservesSelectedCredential
+                    ? "Replace private key"
+                    : "Private key"
+                }
+              >
+                <textarea
+                  className={`${inputClass} min-h-24 py-2 font-mono text-xs`}
+                  value={privateKey}
+                  onChange={(event) => setPrivateKey(event.target.value)}
+                />
+              </Field>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {preservesSelectedCredential
+                  ? "Leave blank to keep the stored key. Enter a value to replace it."
+                  : "A private key is required. Saving removes any stored password."}
+              </p>
+            </div>
+            <div className="md:col-span-2">
+              <Field
+                label={
+                  profile?.hasPrivateKeyPassphrase &&
+                  preservesSelectedCredential
+                    ? "Replace key passphrase"
+                    : "Key passphrase (optional)"
+                }
+              >
+                <input
+                  className={inputClass}
+                  disabled={removePrivateKeyPassphrase}
+                  type="password"
+                  value={privateKeyPassphrase}
+                  onChange={(event) =>
+                    setPrivateKeyPassphrase(event.target.value)
+                  }
+                />
+              </Field>
+              {profile?.hasPrivateKeyPassphrase &&
+                preservesSelectedCredential && (
+                  <label className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                    <input
+                      checked={removePrivateKeyPassphrase}
+                      type="checkbox"
+                      onChange={(event) => {
+                        setRemovePrivateKeyPassphrase(event.target.checked);
+                        if (event.target.checked) setPrivateKeyPassphrase("");
+                      }}
+                    />
+                    Remove the stored passphrase
+                  </label>
+                )}
+              <p className="mt-1 text-xs text-muted-foreground">
+                {profile?.hasPrivateKeyPassphrase && preservesSelectedCredential
+                  ? removePrivateKeyPassphrase
+                    ? "The stored passphrase will be removed."
+                    : "Leave blank to keep the stored passphrase, or enter a value to replace it."
+                  : "Leave blank when the private key has no passphrase."}
+              </p>
+            </div>
+          </>
+        )}
         <div className="md:col-span-2">
           <Field label="Pinned host key fingerprint (SHA-256)">
             <div className="flex gap-2">

--- a/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
+++ b/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
@@ -177,11 +177,24 @@ public sealed class SftpConnectionProfilesController : ControllerBase
             Host = request.Host,
             Port = request.Port,
             Username = request.Username,
+            AuthenticationMethod = ParseAuthenticationMethod(request.AuthenticationMethod),
             Password = request.Password,
             PrivateKey = request.PrivateKey,
             PrivateKeyPassphrase = request.PrivateKeyPassphrase,
+            RemovePrivateKeyPassphrase = request.RemovePrivateKeyPassphrase,
             HostKeyFingerprintSha256 = request.HostKeyFingerprintSha256,
             IsDefault = request.IsDefault
+        };
+    }
+
+    private static SftpAuthenticationMethod ParseAuthenticationMethod(string value)
+    {
+        return value switch
+        {
+            "password" => SftpAuthenticationMethod.Password,
+            "privateKey" => SftpAuthenticationMethod.PrivateKey,
+            _ => throw new ValidationException(
+                "Authentication method must be either 'password' or 'privateKey'.")
         };
     }
 
@@ -193,6 +206,7 @@ public sealed class SftpConnectionProfilesController : ControllerBase
             profile.Host,
             profile.Port,
             profile.Username,
+            profile.EncryptedPrivateKey is not null ? "privateKey" : "password",
             profile.EncryptedPassword is not null,
             profile.EncryptedPrivateKey is not null,
             profile.EncryptedPrivateKeyPassphrase is not null,

--- a/SporeSync.Web/DTO/SftpConnectionProfileResponse.cs
+++ b/SporeSync.Web/DTO/SftpConnectionProfileResponse.cs
@@ -6,6 +6,7 @@ public sealed record SftpConnectionProfileResponse(
     string Host,
     int Port,
     string Username,
+    string AuthenticationMethod,
     bool HasPassword,
     bool HasPrivateKey,
     bool HasPrivateKeyPassphrase,

--- a/SporeSync.Web/DTO/UpsertSftpConnectionProfileRequest.cs
+++ b/SporeSync.Web/DTO/UpsertSftpConnectionProfileRequest.cs
@@ -18,11 +18,16 @@ public sealed record UpsertSftpConnectionProfileRequest(
     [param: MaxLength(200)]
     string Username,
 
+    [param: Required]
+    string AuthenticationMethod,
+
     string? Password,
 
     string? PrivateKey,
 
     string? PrivateKeyPassphrase,
+
+    bool RemovePrivateKeyPassphrase = false,
 
     [param: MaxLength(100)]
     string? HostKeyFingerprintSha256 = null,


### PR DESCRIPTION
Closes #19

## Summary
- add an explicit password/private-key authentication method to profile requests and responses
- atomically clear incompatible stored credentials when switching methods while preserving blank replacement inputs
- support explicit private-key passphrase removal and communicate preserve/replace/remove state in the admin UI
- cover password-to-key, key-to-password, preservation, removal, validation, and API mapping transitions

## Validation
- `dotnet build SporeSync.sln` — passed (10 pre-existing warnings)
- `dotnet test SporeSync.sln` — passed (265 tests)
- `npm run biome:check` — passed
- `npm test` — passed (27 tests)
- `npm run typecheck` — passed