### PR TITLE
Add safe configuration deletion workflows

### DIFF
--- a/SporeSync.Business.Tests/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/DownloadWorkerHostedServiceTests.cs
@@ -602,6 +602,11 @@ public sealed class DownloadWorkerHostedServiceTests : IDisposable
         public Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
+        public Task<SafeDeleteSporeSyncJobResult> SafeDeleteAsync(
+            Guid id,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
         public Task<int> CountByConnectionProfileAsync(Guid connectionProfileId, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
     }

--- a/SporeSync.Business.Tests/EncryptionKeyInitializerTests.cs
+++ b/SporeSync.Business.Tests/EncryptionKeyInitializerTests.cs
@@ -227,5 +227,12 @@ public sealed class EncryptionKeyInitializerTests
         {
             throw new NotSupportedException();
         }
+
+        public Task<SafeDeleteSftpConnectionProfileResult> SafeDeleteAsync(
+            Guid id,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/SporeSync.Business.Tests/RecordingLogger.cs
+++ b/SporeSync.Business.Tests/RecordingLogger.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+
+namespace SporeSync.Business.Tests;
+
+internal sealed class RecordingLogger<T> : ILogger<T>
+{
+    public List<string> Messages { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        Messages.Add(formatter(state, exception));
+    }
+}

--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -1,3 +1,4 @@
+using SporeSync.Domain.Interface;
 using SporeSync.Domain.Model;
 using SporeSync.Infrastructure.Repository;
 
@@ -1135,7 +1136,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
     }
 
     [Fact]
-    public async Task SftpConnectionProfileRepository_DeleteAndJobCount_WorkThroughPostgres()
+    public async Task SftpConnectionProfileRepository_SafeDelete_BlocksReferencesAndRemovesSecretRow()
     {
         var profileRepository = new SftpConnectionProfileRepository(_fixture.DataSource);
         var jobRepository = new SporeSyncJobRepository(_fixture.DataSource);
@@ -1147,13 +1148,43 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
         Assert.Equal(1, await jobRepository.CountByConnectionProfileAsync(usedProfile.Id));
         Assert.Equal(0, await jobRepository.CountByConnectionProfileAsync(unusedProfile.Id));
 
-        Assert.True(await profileRepository.DeleteAsync(unusedProfile.Id));
+        Assert.Equal(
+            SafeDeleteSftpConnectionProfileResult.InUse,
+            await profileRepository.SafeDeleteAsync(usedProfile.Id));
+        var retained = await profileRepository.GetByIdAsync(usedProfile.Id);
+        Assert.NotNull(retained);
+        Assert.NotNull(retained.EncryptedPassword);
+
+        Assert.Equal(
+            SafeDeleteSftpConnectionProfileResult.Deleted,
+            await profileRepository.SafeDeleteAsync(unusedProfile.Id));
         Assert.Null(await profileRepository.GetByIdAsync(unusedProfile.Id));
-        Assert.False(await profileRepository.DeleteAsync(unusedProfile.Id));
+        Assert.Equal(
+            SafeDeleteSftpConnectionProfileResult.NotFound,
+            await profileRepository.SafeDeleteAsync(unusedProfile.Id));
     }
 
     [Fact]
-    public async Task SporeSyncJobRepository_Delete_RemovesJobRunsAndQueueItems()
+    public async Task SporeSyncJobRepository_SafeDelete_BlocksActiveRun()
+    {
+        var profileRepository = new SftpConnectionProfileRepository(_fixture.DataSource);
+        var jobRepository = new SporeSyncJobRepository(_fixture.DataSource);
+        var runRepository = new SporeSyncRunRepository(_fixture.DataSource);
+
+        var profile = await profileRepository.UpsertAsync(CreateProfile());
+        var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
+        var run = await runRepository.CreateAsync(job.Id);
+
+        Assert.Equal(SafeDeleteSporeSyncJobResult.ActiveRunExists, await jobRepository.SafeDeleteAsync(job.Id));
+        Assert.NotNull(await jobRepository.GetByIdAsync(job.Id));
+        Assert.NotNull(await runRepository.GetByIdAsync(run.Id));
+
+        Assert.NotNull(await runRepository.CancelAsync(run.Id));
+        Assert.Equal(SafeDeleteSporeSyncJobResult.Deleted, await jobRepository.SafeDeleteAsync(job.Id));
+    }
+
+    [Fact]
+    public async Task SporeSyncJobRepository_SafeDelete_RemovesCompletedHistory()
     {
         var profileRepository = new SftpConnectionProfileRepository(_fixture.DataSource);
         var jobRepository = new SporeSyncJobRepository(_fixture.DataSource);
@@ -1164,10 +1195,10 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
         var runId = Guid.NewGuid();
         await SeedRunAsync(job.Id, runId, "completed", "/incoming/file.csv");
 
-        Assert.True(await jobRepository.DeleteAsync(job.Id));
+        Assert.Equal(SafeDeleteSporeSyncJobResult.Deleted, await jobRepository.SafeDeleteAsync(job.Id));
         Assert.Null(await jobRepository.GetByIdAsync(job.Id));
         Assert.Null(await runRepository.GetByIdAsync(runId));
-        Assert.False(await jobRepository.DeleteAsync(job.Id));
+        Assert.Equal(SafeDeleteSporeSyncJobResult.NotFound, await jobRepository.SafeDeleteAsync(job.Id));
     }
 
     [Fact]

--- a/SporeSync.Business.Tests/SftpConnectionProfileServiceTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfileServiceTests.cs
@@ -280,13 +280,21 @@ public sealed class SftpConnectionProfileServiceTests
     public async Task DeleteAsync_DeletesProfile_WhenUnused()
     {
         var repository = new RecordingSftpConnectionProfileRepository();
-        var service = CreateService(repository, new RecordingSecretProtector());
+        var logger = new RecordingLogger<SftpConnectionProfileService>();
+        var service = new SftpConnectionProfileService(
+            repository,
+            new CountingSporeSyncJobRepository(),
+            new RecordingSecretProtector(),
+            logger);
         var profileId = Guid.NewGuid();
 
         var status = await service.DeleteAsync(profileId);
 
         Assert.Equal(DeleteSftpConnectionProfileStatus.Deleted, status);
         Assert.Equal(profileId, repository.DeletedId);
+        var message = Assert.Single(logger.Messages);
+        Assert.Contains("Configuration audit: deleted SFTP connection profile", message);
+        Assert.DoesNotContain("never-log-me", message);
     }
 
     private static SftpConnectionProfileService CreateService(
@@ -322,6 +330,11 @@ public sealed class SftpConnectionProfileServiceTests
             => throw new NotSupportedException();
 
         public Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<SafeDeleteSporeSyncJobResult> SafeDeleteAsync(
+            Guid id,
+            CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
     }
 
@@ -363,6 +376,7 @@ public sealed class SftpConnectionProfileServiceTests
             Host = "sftp.example.com",
             Port = 22,
             Username = "sync-user",
+            EncryptedPassword = "protected:never-log-me",
             IsDefault = true
         };
 
@@ -416,6 +430,15 @@ public sealed class SftpConnectionProfileServiceTests
         {
             DeletedId = id;
             return Task.FromResult(true);
+        }
+
+        public async Task<SafeDeleteSftpConnectionProfileResult> SafeDeleteAsync(
+            Guid id,
+            CancellationToken cancellationToken = default)
+        {
+            return await DeleteAsync(id, cancellationToken)
+                ? SafeDeleteSftpConnectionProfileResult.Deleted
+                : SafeDeleteSftpConnectionProfileResult.NotFound;
         }
     }
 }

--- a/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
@@ -81,6 +81,16 @@ public sealed class SftpConnectionProfilesControllerTests
         Assert.IsType<NoContentResult>(result);
     }
 
+    [Fact]
+    public async Task Delete_ReturnsNotFound_WhenProfileDoesNotExist()
+    {
+        var controller = CreateController(deleteStatus: DeleteSftpConnectionProfileStatus.NotFound);
+
+        var result = await controller.Delete(Guid.NewGuid(), CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
     private static SftpConnectionProfilesController CreateController(
         SftpConnectionTestResult? testResult = null,
         DeleteSftpConnectionProfileStatus deleteStatus = DeleteSftpConnectionProfileStatus.Deleted)

--- a/SporeSync.Business.Tests/SporeSyncJobServiceTests.cs
+++ b/SporeSync.Business.Tests/SporeSyncJobServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SporeSync.Business;
 using SporeSync.Business.Interface;
@@ -108,13 +109,15 @@ public sealed class SporeSyncJobServiceTests
     public async Task DeleteAsync_DeletesJob_WhenNoActiveRun()
     {
         var repository = new RecordingSporeSyncJobRepository();
-        var service = CreateService(repository);
+        var logger = new RecordingLogger<SporeSyncJobService>();
+        var service = CreateService(repository, logger: logger);
         var jobId = Guid.NewGuid();
 
         var status = await service.DeleteAsync(jobId);
 
         Assert.Equal(DeleteSporeSyncJobStatus.Deleted, status);
         Assert.Equal(jobId, repository.DeletedId);
+        Assert.Contains("Configuration audit: deleted sync job", Assert.Single(logger.Messages));
     }
 
     private static string TestDestinationRoot =>
@@ -122,7 +125,8 @@ public sealed class SporeSyncJobServiceTests
 
     private static SporeSyncJobService CreateService(
         RecordingSporeSyncJobRepository repository,
-        bool hasActiveRun = false)
+        bool hasActiveRun = false,
+        ILogger<SporeSyncJobService>? logger = null)
     {
         var sandbox = new LocalDestinationPathSandbox(Options.Create(new SporeSyncOptions
         {
@@ -132,7 +136,8 @@ public sealed class SporeSyncJobServiceTests
         return new SporeSyncJobService(
             repository,
             new FakeSporeSyncRunRepository { HasActiveRun = hasActiveRun },
-            sandbox);
+            sandbox,
+            logger);
     }
 
     private sealed class RecordingSporeSyncJobRepository : ISporeSyncJobRepository
@@ -213,6 +218,15 @@ public sealed class SporeSyncJobServiceTests
         {
             DeletedId = id;
             return Task.FromResult(true);
+        }
+
+        public async Task<SafeDeleteSporeSyncJobResult> SafeDeleteAsync(
+            Guid id,
+            CancellationToken cancellationToken = default)
+        {
+            return await DeleteAsync(id, cancellationToken)
+                ? SafeDeleteSporeSyncJobResult.Deleted
+                : SafeDeleteSporeSyncJobResult.NotFound;
         }
 
         public Task<int> CountByConnectionProfileAsync(Guid connectionProfileId, CancellationToken cancellationToken = default)

--- a/SporeSync.Business.Tests/SporeSyncJobsControllerRunTests.cs
+++ b/SporeSync.Business.Tests/SporeSyncJobsControllerRunTests.cs
@@ -26,8 +26,39 @@ public sealed class SporeSyncJobsControllerRunTests
         Assert.Equal(StatusCodes.Status409Conflict, problem.Status);
     }
 
+    [Fact]
+    public async Task Delete_ReturnsConflict_WhenActiveRunExists()
+    {
+        var controller = CreateController(DeleteSporeSyncJobStatus.ActiveRunExists);
+
+        var result = await controller.Delete(Guid.NewGuid(), CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal(StatusCodes.Status409Conflict, problem.Status);
+    }
+
+    [Fact]
+    public async Task Delete_ReturnsNotFound_WhenJobDoesNotExist()
+    {
+        var controller = CreateController(DeleteSporeSyncJobStatus.NotFound);
+
+        var result = await controller.Delete(Guid.NewGuid(), CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    private static SporeSyncJobsController CreateController(DeleteSporeSyncJobStatus deleteStatus)
+    {
+        return new SporeSyncJobsController(
+            new FakeSporeSyncJobService { DeleteStatus = deleteStatus },
+            new FakeSyncJobRunService { Result = new SyncJobRunResult { Error = SyncJobRunError.NotFound } });
+    }
+
     private sealed class FakeSporeSyncJobService : ISporeSyncJobService
     {
+        public DeleteSporeSyncJobStatus DeleteStatus { get; init; }
+
         public Task<IReadOnlyCollection<SporeSyncJob>> GetConfiguredJobsAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyCollection<SporeSyncJob>>(Array.Empty<SporeSyncJob>());
 
@@ -38,7 +69,7 @@ public sealed class SporeSyncJobsControllerRunTests
             => throw new NotImplementedException();
 
         public Task<DeleteSporeSyncJobStatus> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
-            => throw new NotImplementedException();
+            => Task.FromResult(DeleteStatus);
     }
 
     private sealed class FakeSyncJobRunService : ISyncJobRunService

--- a/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/Worker/DownloadWorkerHostedServiceTests.cs
@@ -617,6 +617,11 @@ public sealed class DownloadWorkerHostedServiceTests
         public Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
 
+        public Task<SafeDeleteSporeSyncJobResult> SafeDeleteAsync(
+            Guid id,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
         public Task<int> CountByConnectionProfileAsync(Guid connectionProfileId, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
     }

--- a/SporeSync.Business/Service/SftpConnectionProfileService.cs
+++ b/SporeSync.Business/Service/SftpConnectionProfileService.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using SporeSync.Business.Interface;
 using SporeSync.Business.Sftp;
 using SporeSync.Domain.Interface;
@@ -11,15 +13,18 @@ public sealed class SftpConnectionProfileService : ISftpConnectionProfileService
     private readonly ISftpConnectionProfileRepository _repository;
     private readonly ISporeSyncJobRepository _jobRepository;
     private readonly ISecretProtector _secretProtector;
+    private readonly ILogger<SftpConnectionProfileService> _logger;
 
     public SftpConnectionProfileService(
         ISftpConnectionProfileRepository repository,
         ISporeSyncJobRepository jobRepository,
-        ISecretProtector secretProtector)
+        ISecretProtector secretProtector,
+        ILogger<SftpConnectionProfileService>? logger = null)
     {
         _repository = repository;
         _jobRepository = jobRepository;
         _secretProtector = secretProtector;
+        _logger = logger ?? NullLogger<SftpConnectionProfileService>.Instance;
     }
 
     public Task<IReadOnlyCollection<SftpConnectionProfile>> GetAllAsync(
@@ -104,8 +109,21 @@ public sealed class SftpConnectionProfileService : ISftpConnectionProfileService
             return DeleteSftpConnectionProfileStatus.InUse;
         }
 
-        var deleted = await _repository.DeleteAsync(id, cancellationToken);
-        return deleted ? DeleteSftpConnectionProfileStatus.Deleted : DeleteSftpConnectionProfileStatus.NotFound;
+        var result = await _repository.SafeDeleteAsync(id, cancellationToken);
+        if (result == SafeDeleteSftpConnectionProfileResult.Deleted)
+        {
+            _logger.LogInformation(
+                "Configuration audit: deleted SFTP connection profile {ProfileId} ({ProfileName}) and its stored credentials",
+                profile.Id,
+                profile.Name);
+        }
+
+        return result switch
+        {
+            SafeDeleteSftpConnectionProfileResult.Deleted => DeleteSftpConnectionProfileStatus.Deleted,
+            SafeDeleteSftpConnectionProfileResult.InUse => DeleteSftpConnectionProfileStatus.InUse,
+            _ => DeleteSftpConnectionProfileStatus.NotFound
+        };
     }
 
     private string? ProtectOptional(string? value)

--- a/SporeSync.Business/Service/SporeSyncJobService.cs
+++ b/SporeSync.Business/Service/SporeSyncJobService.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using SporeSync.Business.Interface;
 using SporeSync.Business.Security;
 using SporeSync.Domain.Interface;
@@ -10,15 +12,18 @@ public sealed class SporeSyncJobService : ISporeSyncJobService
     private readonly ISporeSyncJobRepository _sporeSyncJobRepository;
     private readonly ISporeSyncRunRepository _sporeSyncRunRepository;
     private readonly LocalDestinationPathSandbox _destinationPathSandbox;
+    private readonly ILogger<SporeSyncJobService> _logger;
 
     public SporeSyncJobService(
         ISporeSyncJobRepository sporeSyncJobRepository,
         ISporeSyncRunRepository sporeSyncRunRepository,
-        LocalDestinationPathSandbox destinationPathSandbox)
+        LocalDestinationPathSandbox destinationPathSandbox,
+        ILogger<SporeSyncJobService>? logger = null)
     {
         _sporeSyncJobRepository = sporeSyncJobRepository;
         _sporeSyncRunRepository = sporeSyncRunRepository;
         _destinationPathSandbox = destinationPathSandbox;
+        _logger = logger ?? NullLogger<SporeSyncJobService>.Instance;
     }
 
     public Task<IReadOnlyCollection<SporeSyncJob>> GetConfiguredJobsAsync(
@@ -67,7 +72,20 @@ public sealed class SporeSyncJobService : ISporeSyncJobService
             return DeleteSporeSyncJobStatus.ActiveRunExists;
         }
 
-        var deleted = await _sporeSyncJobRepository.DeleteAsync(id, cancellationToken);
-        return deleted ? DeleteSporeSyncJobStatus.Deleted : DeleteSporeSyncJobStatus.NotFound;
+        var result = await _sporeSyncJobRepository.SafeDeleteAsync(id, cancellationToken);
+        if (result == SafeDeleteSporeSyncJobResult.Deleted)
+        {
+            _logger.LogInformation(
+                "Configuration audit: deleted sync job {JobId} ({JobName}); history removed and local files retained",
+                job.Id,
+                job.Name);
+        }
+
+        return result switch
+        {
+            SafeDeleteSporeSyncJobResult.Deleted => DeleteSporeSyncJobStatus.Deleted,
+            SafeDeleteSporeSyncJobResult.ActiveRunExists => DeleteSporeSyncJobStatus.ActiveRunExists,
+            _ => DeleteSporeSyncJobStatus.NotFound
+        };
     }
 }

--- a/SporeSync.Domain/Interface/ISftpConnectionProfileRepository.cs
+++ b/SporeSync.Domain/Interface/ISftpConnectionProfileRepository.cs
@@ -2,6 +2,13 @@ using SporeSync.Domain.Model;
 
 namespace SporeSync.Domain.Interface;
 
+public enum SafeDeleteSftpConnectionProfileResult
+{
+    Deleted,
+    NotFound,
+    InUse
+}
+
 public interface ISftpConnectionProfileRepository
 {
     Task<IReadOnlyCollection<SftpConnectionProfile>> GetAllAsync(CancellationToken cancellationToken = default);
@@ -23,4 +30,8 @@ public interface ISftpConnectionProfileRepository
     /// Deletes a connection profile. Returns false when the profile does not exist.
     /// </summary>
     Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<SafeDeleteSftpConnectionProfileResult> SafeDeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
 }

--- a/SporeSync.Domain/Interface/ISporeSyncJobRepository.cs
+++ b/SporeSync.Domain/Interface/ISporeSyncJobRepository.cs
@@ -2,6 +2,13 @@ using SporeSync.Domain.Model;
 
 namespace SporeSync.Domain.Interface;
 
+public enum SafeDeleteSporeSyncJobResult
+{
+    Deleted,
+    NotFound,
+    ActiveRunExists
+}
+
 public interface ISporeSyncJobRepository
 {
     Task<IReadOnlyCollection<SporeSyncJob>> GetAllAsync(CancellationToken cancellationToken = default);
@@ -18,6 +25,10 @@ public interface ISporeSyncJobRepository
     /// Deletes a job together with its runs and queue items. Returns false when the job does not exist.
     /// </summary>
     Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+
+    Task<SafeDeleteSporeSyncJobResult> SafeDeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
 
     Task<int> CountByConnectionProfileAsync(Guid connectionProfileId, CancellationToken cancellationToken = default);
 }

--- a/SporeSync.Infrastructure/Migrations/SafeConfigurationDeletionMigration.cs
+++ b/SporeSync.Infrastructure/Migrations/SafeConfigurationDeletionMigration.cs
@@ -1,0 +1,24 @@
+using FluentMigrator;
+
+namespace SporeSync.Infrastructure.Migrations;
+
+[Migration(202607110009)]
+public sealed class SafeConfigurationDeletionMigration : Migration
+{
+    private const string UpPrefix = "SporeSync.Infrastructure.Migrations.Schema.Functions.202607110009_SafeConfigurationDeletion.Up.Post.";
+    private const string DownPrefix = "SporeSync.Infrastructure.Migrations.Schema.Functions.202607110009_SafeConfigurationDeletion.Down.Pre.";
+
+    public override void Up()
+    {
+        EmbeddedSqlScripts.ExecuteSqlScripts(
+            this,
+            EmbeddedSqlScripts.ReadEmbeddedScriptsByPrefix(typeof(SafeConfigurationDeletionMigration).Assembly, UpPrefix));
+    }
+
+    public override void Down()
+    {
+        EmbeddedSqlScripts.ExecuteSqlScripts(
+            this,
+            EmbeddedSqlScripts.ReadEmbeddedScriptsByPrefix(typeof(SafeConfigurationDeletionMigration).Assembly, DownPrefix));
+    }
+}

--- a/SporeSync.Infrastructure/Migrations/Schema/Functions/202607110009_SafeConfigurationDeletion/Down/Pre/001_drop_safe_configuration_deletion.sql
+++ b/SporeSync.Infrastructure/Migrations/Schema/Functions/202607110009_SafeConfigurationDeletion/Down/Pre/001_drop_safe_configuration_deletion.sql
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS core.safe_delete_sftp_sync_job(uuid);
+DROP FUNCTION IF EXISTS core.safe_delete_sftp_connection_profile(uuid);

--- a/SporeSync.Infrastructure/Migrations/Schema/Functions/202607110009_SafeConfigurationDeletion/Up/Post/001_safe_configuration_deletion.sql
+++ b/SporeSync.Infrastructure/Migrations/Schema/Functions/202607110009_SafeConfigurationDeletion/Up/Post/001_safe_configuration_deletion.sql
@@ -1,0 +1,42 @@
+CREATE FUNCTION core.safe_delete_sftp_sync_job(p_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM 1 FROM core.sftp_sync_jobs WHERE id = p_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RETURN 'not_found';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM core.sftp_sync_runs
+        WHERE job_id = p_id AND status IN ('queued', 'scanning', 'downloading')
+    ) THEN
+        RETURN 'active_run';
+    END IF;
+
+    DELETE FROM core.download_queue_items WHERE job_id = p_id;
+    DELETE FROM core.sftp_sync_runs WHERE job_id = p_id;
+    DELETE FROM core.sftp_sync_jobs WHERE id = p_id;
+    RETURN 'deleted';
+END;
+$$;
+
+CREATE FUNCTION core.safe_delete_sftp_connection_profile(p_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM 1 FROM core.sftp_connection_profiles WHERE id = p_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RETURN 'not_found';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM core.sftp_sync_jobs WHERE connection_profile_id = p_id) THEN
+        RETURN 'in_use';
+    END IF;
+
+    DELETE FROM core.sftp_connection_profiles WHERE id = p_id;
+    RETURN 'deleted';
+END;
+$$;

--- a/SporeSync.Infrastructure/Repository/SftpConnectionProfileRepository.cs
+++ b/SporeSync.Infrastructure/Repository/SftpConnectionProfileRepository.cs
@@ -204,6 +204,26 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
         return await DbCommandLogger.ExecuteScalarAsync<bool>(_logger, command, OpDeleteProfile, cancellationToken);
     }
 
+    public async Task<SafeDeleteSftpConnectionProfileResult> SafeDeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = "SELECT core.safe_delete_sftp_connection_profile(@id);";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("id", id);
+
+        var result = await DbCommandLogger.ExecuteScalarAsync<string>(_logger, command, OpDeleteProfile, cancellationToken);
+        return result switch
+        {
+            "deleted" => SafeDeleteSftpConnectionProfileResult.Deleted,
+            "not_found" => SafeDeleteSftpConnectionProfileResult.NotFound,
+            "in_use" => SafeDeleteSftpConnectionProfileResult.InUse,
+            _ => throw new InvalidOperationException($"Unexpected safe profile deletion result '{result}'.")
+        };
+    }
+
     private static SftpConnectionProfile ReadProfile(NpgsqlDataReader reader)
     {
         return new SftpConnectionProfile

--- a/SporeSync.Infrastructure/Repository/SporeSyncJobRepository.cs
+++ b/SporeSync.Infrastructure/Repository/SporeSyncJobRepository.cs
@@ -198,6 +198,26 @@ public sealed class SporeSyncJobRepository : ISporeSyncJobRepository
         return await DbCommandLogger.ExecuteScalarAsync<bool>(_logger, command, OpDeleteJob, cancellationToken);
     }
 
+    public async Task<SafeDeleteSporeSyncJobResult> SafeDeleteAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        const string sql = "SELECT core.safe_delete_sftp_sync_job(@id);";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("id", id);
+
+        var result = await DbCommandLogger.ExecuteScalarAsync<string>(_logger, command, OpDeleteJob, cancellationToken);
+        return result switch
+        {
+            "deleted" => SafeDeleteSporeSyncJobResult.Deleted,
+            "not_found" => SafeDeleteSporeSyncJobResult.NotFound,
+            "active_run" => SafeDeleteSporeSyncJobResult.ActiveRunExists,
+            _ => throw new InvalidOperationException($"Unexpected safe job deletion result '{result}'.")
+        };
+    }
+
     public async Task<int> CountByConnectionProfileAsync(
         Guid connectionProfileId,
         CancellationToken cancellationToken = default)

--- a/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
@@ -95,7 +95,7 @@ export function JobsPage() {
   const deleteJob = (job: SporeSyncJob) => {
     if (
       window.confirm(
-        `Delete job "${job.name}"?\n\nIts run history and queue items will also be removed.`,
+        `Delete job "${job.name}"?\n\nIts run history and queue items will be removed. Downloaded local files will be kept. Active runs must be cancelled first.`,
       )
     ) {
       deleteMutation.mutate(job);
@@ -272,7 +272,11 @@ export function ProfilesPage() {
   });
 
   const deleteProfile = (profile: SftpConnectionProfile) => {
-    if (window.confirm(`Delete profile "${profile.name}"?`)) {
+    if (
+      window.confirm(
+        `Delete profile "${profile.name}"?\n\nIts stored credentials will be removed. Referencing jobs must be reassigned or deleted first. Downloaded local files and run history will be kept.`,
+      )
+    ) {
       deleteMutation.mutate(profile);
     }
   };


### PR DESCRIPTION
Closes #23

## Summary
- make job/profile deletion dependency-aware and atomic in PostgreSQL
- block job deletion during active runs and profile deletion while jobs reference it
- retain downloaded local files, remove job history only after explicit confirmation, and remove profile credential rows on success
- emit structured deletion audit logs without credential values
- clarify deletion effects in the admin UI and return consistent 404/409 responses

## Validation
- `dotnet build SporeSync.sln` — passed (existing package/analyzer warnings)
- `dotnet test SporeSync.sln --no-build` — passed, 262 tests
- `npm run biome:check` from `SporeSync.Web/ClientApp` — passed
- `npm test` from `SporeSync.Web/ClientApp` — passed, 27 tests