### PR TITLE
Verify trusted SFTP host keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ For local development without Testcontainers, create a matching PostgreSQL datab
 
 Configure an SFTP connection profile and sync job through the admin UI or REST API (`/api/sftp-connection-profiles`, `/api/sftp-sync-jobs`). Trigger an immediate run with `POST /api/sftp-sync-jobs/{id}/run`. Enabled jobs are polled automatically every 10 seconds (configurable via `SporeSync:SchedulerIntervalSeconds`).
 
+### SFTP host key verification
+
+Every connection profile must contain at least one trusted SHA-256 SSH host-key
+fingerprint. Use **Fetch** in the admin profile form to observe the server's
+algorithm and fingerprint, verify that fingerprint through a separate trusted
+channel, and then save it. Fetching never trusts the key automatically. Multiple
+fingerprints may be saved during a planned rotation; remove the old fingerprint
+after the server has stopped using it.
+
+Upgrades preserve and migrate any previously pinned fingerprint. Profiles that
+did not already have one remain with an empty trust list and fail closed until an
+administrator verifies and saves a fingerprint; there is no trust-on-first-use
+compatibility mode.
+
 Worker settings in `appsettings.json`:
 
 ```json

--- a/SporeSync.Business.Tests/DownloadWorkerHostedServiceTests.cs
+++ b/SporeSync.Business.Tests/DownloadWorkerHostedServiceTests.cs
@@ -47,7 +47,7 @@ public sealed class DownloadWorkerHostedServiceTests : IDisposable
                 new ThrowingSftpClientFactory(new SshHostKeyMismatchException(
                     "sftp.example.com",
                     22,
-                    "SHA256:expected",
+                    ["SHA256:expected"],
                     "SHA256:actual")),
                 new LocalDestinationPathSandbox(Options.Create(new SporeSyncOptions
                 {

--- a/SporeSync.Business.Tests/EncryptionKeyInitializerTests.cs
+++ b/SporeSync.Business.Tests/EncryptionKeyInitializerTests.cs
@@ -210,14 +210,6 @@ public sealed class EncryptionKeyInitializerTests
             throw new NotSupportedException();
         }
 
-        public Task<bool> TryPinHostKeyFingerprintAsync(
-            Guid id,
-            string fingerprintSha256,
-            CancellationToken cancellationToken = default)
-        {
-            throw new NotSupportedException();
-        }
-
         public Task<bool> HasAnyEncryptedSecretsAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(HasEncryptedSecrets);

--- a/SporeSync.Business.Tests/MigrationDiscoveryTests.cs
+++ b/SporeSync.Business.Tests/MigrationDiscoveryTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using FluentMigrator;
+using SporeSync.Infrastructure.Migrations;
+
+namespace SporeSync.Business.Tests;
+
+public sealed class MigrationDiscoveryTests
+{
+    [Fact]
+    public void InfrastructureMigrations_HaveUniqueVersions()
+    {
+        var duplicateVersions = typeof(AddTrustedHostKeysMigration).Assembly
+            .GetTypes()
+            .Select(type => type.GetCustomAttribute<MigrationAttribute>()?.Version)
+            .Where(version => version.HasValue)
+            .Select(version => version.GetValueOrDefault())
+            .GroupBy(version => version)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToArray();
+
+        Assert.Empty(duplicateVersions);
+    }
+}

--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -76,7 +76,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
     }
 
     [Fact]
-    public async Task SftpConnectionProfileRepository_TryPinHostKeyFingerprint_OnlyUpdatesNullPin()
+    public async Task SftpConnectionProfileRepository_RoundTripsMultipleTrustedHostKeys()
     {
         var repository = new SftpConnectionProfileRepository(_fixture.DataSource);
         var profile = await repository.UpsertAsync(new SftpConnectionProfile
@@ -89,36 +89,16 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
             EncryptedPassword = "encrypted-password",
             IsDefault = false
         });
-        await repository.UpsertAsync(new SftpConnectionProfile
-        {
-            Id = profile.Id,
-            Name = "concurrently-edited",
-            Host = "edited.example.com",
-            Port = 2222,
-            Username = "edited-user",
-            EncryptedPassword = "edited-password",
-            IsDefault = false
-        });
-
-        var pinned = await repository.TryPinHostKeyFingerprintAsync(
-            profile.Id,
-            "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8");
-        var repinned = await repository.TryPinHostKeyFingerprintAsync(
-            profile.Id,
-            "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        profile.TrustedHostKeyFingerprintsSha256 =
+        [
+            "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8",
+            "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        ];
+        await repository.UpsertAsync(profile);
         var fetched = await repository.GetByIdAsync(profile.Id);
 
-        Assert.True(pinned);
-        Assert.False(repinned);
         Assert.NotNull(fetched);
-        Assert.Equal("concurrently-edited", fetched.Name);
-        Assert.Equal("edited.example.com", fetched.Host);
-        Assert.Equal(2222, fetched.Port);
-        Assert.Equal("edited-user", fetched.Username);
-        Assert.Equal("edited-password", fetched.EncryptedPassword);
-        Assert.Equal(
-            "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8",
-            fetched.HostKeyFingerprintSha256);
+        Assert.Equivalent(profile.TrustedHostKeyFingerprintsSha256, fetched.TrustedHostKeyFingerprintsSha256);
     }
 
     [Fact]

--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -1153,7 +1153,8 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.CreateAsync(job.Id);
+        var run = await runRepository.TryCreateAsync(job.Id);
+        Assert.NotNull(run);
 
         Assert.Equal(SafeDeleteSporeSyncJobResult.ActiveRunExists, await jobRepository.SafeDeleteAsync(job.Id));
         Assert.NotNull(await jobRepository.GetByIdAsync(job.Id));

--- a/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
@@ -203,7 +203,7 @@ public sealed class SftpSyncEndToEndTests :
     }
 
     [Fact]
-    public async Task HostKeyVerification_FailsClosedAndSupportsRotation()
+    public async Task HostKeyVerification_FailsClosedSupportsRotationAndPreservesAuthFailures()
     {
         using var scope = _provider.CreateScope();
         var services = scope.ServiceProvider;
@@ -211,6 +211,10 @@ public sealed class SftpSyncEndToEndTests :
         var observed = (await services.GetRequiredService<ISshHostKeyScanner>()
             .ScanAsync(_sftp.Host, _sftp.Port)).FingerprintSha256;
         const string other = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        var badCredentials = await CreateProfileAsync(services, "bad-auth", [observed], "wrong-password");
+        await Assert.ThrowsAsync<Renci.SshNet.Common.SshAuthenticationException>(
+            () => factory.ConnectAsync(badCredentials.Id));
 
         foreach (var trusted in new IReadOnlyList<string>[] { [], [other] })
         {
@@ -251,7 +255,8 @@ public sealed class SftpSyncEndToEndTests :
     private async Task<SftpConnectionProfile> CreateProfileAsync(
         IServiceProvider services,
         string caseName,
-        IReadOnlyList<string> trustedHostKeys)
+        IReadOnlyList<string> trustedHostKeys,
+        string password = SftpTestcontainerFixture.Password)
     {
         return await services.GetRequiredService<ISftpConnectionProfileRepository>().UpsertAsync(
             new SftpConnectionProfile
@@ -262,7 +267,7 @@ public sealed class SftpSyncEndToEndTests :
                 Port = _sftp.Port,
                 Username = SftpTestcontainerFixture.Username,
                 EncryptedPassword = services.GetRequiredService<ISecretProtector>()
-                    .Protect(SftpTestcontainerFixture.Password),
+                    .Protect(password),
                 TrustedHostKeyFingerprintsSha256 = trustedHostKeys,
                 IsDefault = false
             });

--- a/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpSyncEndToEndTests.cs
@@ -60,6 +60,7 @@ public sealed class SftpSyncEndToEndTests :
         services.AddScoped<ISporeSyncRunRepository, SporeSyncRunRepository>();
         services.AddScoped<IDownloadQueueItemRepository, DownloadQueueItemRepository>();
         services.AddScoped<ISftpClientFactory, SftpClientFactory>();
+        services.AddScoped<ISshHostKeyScanner, SshHostKeyScanner>();
         services.AddScoped<RealSftpDirectoryScanner>();
         services.AddScoped<ISftpFileDownloader, SftpFileDownloader>();
         services.AddSingleton<DownloadRetryPolicy>();
@@ -201,25 +202,40 @@ public sealed class SftpSyncEndToEndTests :
         Assert.Equal("keep me", await File.ReadAllTextAsync(Path.Combine(destination, "keep.txt")));
     }
 
+    [Fact]
+    public async Task HostKeyVerification_FailsClosedAndSupportsRotation()
+    {
+        using var scope = _provider.CreateScope();
+        var services = scope.ServiceProvider;
+        var factory = services.GetRequiredService<ISftpClientFactory>();
+        var observed = (await services.GetRequiredService<ISshHostKeyScanner>()
+            .ScanAsync(_sftp.Host, _sftp.Port)).FingerprintSha256;
+        const string other = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        foreach (var trusted in new IReadOnlyList<string>[] { [], [other] })
+        {
+            var profile = await CreateProfileAsync(services, "rejected", trusted);
+            var exception = await Assert.ThrowsAsync<SshHostKeyMismatchException>(
+                () => factory.ConnectAsync(profile.Id));
+            Assert.Equal(_sftp.Host, exception.Host);
+            Assert.Equal(observed, exception.ActualFingerprint);
+            Assert.DoesNotContain(SftpTestcontainerFixture.Password, exception.Message);
+        }
+
+        var rotating = await CreateProfileAsync(services, "rotation", [other, observed]);
+        await using var connection = await factory.ConnectAsync(rotating.Id);
+        Assert.True(connection.IsConnected);
+    }
+
     private async Task<SporeSyncJob> CreateJobAsync(
         IServiceProvider services,
         string sourcePath,
         string caseName)
     {
-        var profileRepository = services.GetRequiredService<ISftpConnectionProfileRepository>();
         var jobRepository = services.GetRequiredService<ISporeSyncJobRepository>();
-        var protector = services.GetRequiredService<ISecretProtector>();
-
-        var profile = await profileRepository.UpsertAsync(new SftpConnectionProfile
-        {
-            Id = Guid.NewGuid(),
-            Name = $"sftp-e2e-{caseName}-{Guid.NewGuid():N}",
-            Host = _sftp.Host,
-            Port = _sftp.Port,
-            Username = SftpTestcontainerFixture.Username,
-            EncryptedPassword = protector.Protect(SftpTestcontainerFixture.Password),
-            IsDefault = false
-        });
+        var observed = (await services.GetRequiredService<ISshHostKeyScanner>()
+            .ScanAsync(_sftp.Host, _sftp.Port)).FingerprintSha256;
+        var profile = await CreateProfileAsync(services, caseName, [observed]);
 
         return await jobRepository.UpsertAsync(new UpsertSporeSyncJob
         {
@@ -230,6 +246,26 @@ public sealed class SftpSyncEndToEndTests :
             PollingIntervalSeconds = 120,
             IsEnabled = true
         });
+    }
+
+    private async Task<SftpConnectionProfile> CreateProfileAsync(
+        IServiceProvider services,
+        string caseName,
+        IReadOnlyList<string> trustedHostKeys)
+    {
+        return await services.GetRequiredService<ISftpConnectionProfileRepository>().UpsertAsync(
+            new SftpConnectionProfile
+            {
+                Id = Guid.NewGuid(),
+                Name = $"sftp-e2e-{caseName}-{Guid.NewGuid():N}",
+                Host = _sftp.Host,
+                Port = _sftp.Port,
+                Username = SftpTestcontainerFixture.Username,
+                EncryptedPassword = services.GetRequiredService<ISecretProtector>()
+                    .Protect(SftpTestcontainerFixture.Password),
+                TrustedHostKeyFingerprintsSha256 = trustedHostKeys,
+                IsDefault = false
+            });
     }
 
     private string DestinationFor(string caseName) => Path.Combine(_destinationRoot, caseName);

--- a/SporeSync.Business.Tests/SftpConnectionProfileServiceTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfileServiceTests.cs
@@ -247,7 +247,7 @@ public sealed class SftpConnectionProfileServiceTests
     }
 
     [Fact]
-    public async Task UpsertAsync_NormalizesAndStoresHostKeyFingerprint()
+    public async Task UpsertAsync_NormalizesDeduplicatesAndStoresTrustedHostKeys()
     {
         var repository = new RecordingSftpConnectionProfileRepository();
         var service = CreateService(repository, new RecordingSecretProtector());
@@ -259,17 +259,21 @@ public sealed class SftpConnectionProfileServiceTests
                 Host = "sftp.example.com",
                 Username = "sync-user",
                 Password = "password",
-                HostKeyFingerprintSha256 = "nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8="
+                TrustedHostKeyFingerprintsSha256 =
+                [
+                    "nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8=",
+                    "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"
+                ]
             });
 
         Assert.NotNull(repository.LastUpsertedProfile);
-        Assert.Equal(
+        Assert.Equal([
             "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8",
-            repository.LastUpsertedProfile.HostKeyFingerprintSha256);
+        ], repository.LastUpsertedProfile.TrustedHostKeyFingerprintsSha256);
     }
 
     [Fact]
-    public async Task UpsertAsync_Throws_WhenHostKeyFingerprintIsInvalid()
+    public async Task UpsertAsync_Throws_WhenTrustedHostKeyIsInvalid()
     {
         var repository = new RecordingSftpConnectionProfileRepository();
         var service = CreateService(repository, new RecordingSecretProtector());
@@ -282,14 +286,14 @@ public sealed class SftpConnectionProfileServiceTests
                     Host = "sftp.example.com",
                     Username = "sync-user",
                     Password = "password",
-                    HostKeyFingerprintSha256 = "not-a-fingerprint"
+                    TrustedHostKeyFingerprintsSha256 = ["not-a-fingerprint"]
                 }));
 
         Assert.Null(repository.LastUpsertedProfile);
     }
 
     [Fact]
-    public async Task UpsertAsync_PreservesHostKeyFingerprint_WhenRequestValueIsNull()
+    public async Task UpsertAsync_PreservesTrustedHostKeys_WhenRequestValueIsNull()
     {
         var profileId = Guid.NewGuid();
         var repository = new RecordingSftpConnectionProfileRepository
@@ -302,7 +306,8 @@ public sealed class SftpConnectionProfileServiceTests
                 Port = 22,
                 Username = "sync-user",
                 EncryptedPassword = "existing-password",
-                HostKeyFingerprintSha256 = "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8",
+                TrustedHostKeyFingerprintsSha256 =
+                    ["SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"],
                 IsDefault = true
             }
         };
@@ -315,17 +320,17 @@ public sealed class SftpConnectionProfileServiceTests
                 Name = "existing",
                 Host = "sftp.example.com",
                 Username = "sync-user",
-                HostKeyFingerprintSha256 = null
+                TrustedHostKeyFingerprintsSha256 = null
             });
 
         Assert.NotNull(repository.LastUpsertedProfile);
-        Assert.Equal(
+        Assert.Equal([
             "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8",
-            repository.LastUpsertedProfile.HostKeyFingerprintSha256);
+        ], repository.LastUpsertedProfile.TrustedHostKeyFingerprintsSha256);
     }
 
     [Fact]
-    public async Task UpsertAsync_ClearsHostKeyFingerprint_WhenRequestValueIsBlank()
+    public async Task UpsertAsync_ClearsTrustedHostKeys_WhenRequestCollectionIsEmpty()
     {
         var profileId = Guid.NewGuid();
         var repository = new RecordingSftpConnectionProfileRepository
@@ -338,7 +343,8 @@ public sealed class SftpConnectionProfileServiceTests
                 Port = 22,
                 Username = "sync-user",
                 EncryptedPassword = "existing-password",
-                HostKeyFingerprintSha256 = "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8",
+                TrustedHostKeyFingerprintsSha256 =
+                    ["SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8"],
                 IsDefault = true
             }
         };
@@ -351,11 +357,11 @@ public sealed class SftpConnectionProfileServiceTests
                 Name = "existing",
                 Host = "sftp.example.com",
                 Username = "sync-user",
-                HostKeyFingerprintSha256 = " "
+                TrustedHostKeyFingerprintsSha256 = []
             });
 
         Assert.NotNull(repository.LastUpsertedProfile);
-        Assert.Null(repository.LastUpsertedProfile.HostKeyFingerprintSha256);
+        Assert.Empty(repository.LastUpsertedProfile.TrustedHostKeyFingerprintsSha256);
     }
 
     [Fact]
@@ -544,14 +550,6 @@ public sealed class SftpConnectionProfileServiceTests
             LastUpsertedProfile = profile;
             LastCancellationToken = cancellationToken;
             return Task.FromResult(profile);
-        }
-
-        public Task<bool> TryPinHostKeyFingerprintAsync(
-            Guid id,
-            string fingerprintSha256,
-            CancellationToken cancellationToken = default)
-        {
-            throw new NotSupportedException();
         }
 
         public Task<bool> HasAnyEncryptedSecretsAsync(CancellationToken cancellationToken = default)

--- a/SporeSync.Business/Service/SftpConnectionProfileService.cs
+++ b/SporeSync.Business/Service/SftpConnectionProfileService.cs
@@ -63,9 +63,9 @@ public sealed class SftpConnectionProfileService : ISftpConnectionProfileService
             EncryptedPassword = encryptedPassword,
             EncryptedPrivateKey = encryptedPrivateKey,
             EncryptedPrivateKeyPassphrase = encryptedPrivateKeyPassphrase,
-            HostKeyFingerprintSha256 = ResolveHostKeyFingerprint(
-                profile.HostKeyFingerprintSha256,
-                existingProfile?.HostKeyFingerprintSha256),
+            TrustedHostKeyFingerprintsSha256 = ResolveHostKeyFingerprints(
+                profile.TrustedHostKeyFingerprintsSha256,
+                existingProfile?.TrustedHostKeyFingerprintsSha256),
             IsDefault = profile.IsDefault
         };
 
@@ -105,18 +105,19 @@ public sealed class SftpConnectionProfileService : ISftpConnectionProfileService
         return (null, privateKey, passphrase);
     }
 
-    private static string? ResolveHostKeyFingerprint(string? requested, string? existing)
+    private static IReadOnlyList<string> ResolveHostKeyFingerprints(
+        IReadOnlyList<string>? requested,
+        IReadOnlyList<string>? existing)
     {
-        // Null preserves the stored pin; an explicit blank clears it (re-enabling
-        // trust-on-first-use); any other value replaces the pin after normalization.
         if (requested is null)
         {
-            return existing;
+            return existing ?? [];
         }
 
-        return string.IsNullOrWhiteSpace(requested)
-            ? null
-            : SshHostKeyFingerprint.Normalize(requested);
+        return requested
+            .Select(SshHostKeyFingerprint.Normalize)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 
     public async Task<DeleteSftpConnectionProfileStatus> DeleteAsync(

--- a/SporeSync.Business/Sftp/SftpClientFactory.cs
+++ b/SporeSync.Business/Sftp/SftpClientFactory.cs
@@ -74,13 +74,14 @@ public sealed class SftpClientFactory : ISftpClientFactory
         };
 
         var trustedFingerprints = profile.TrustedHostKeyFingerprintsSha256;
-        string? presentedFingerprint = null;
+        string? untrustedFingerprint = null;
 
         client.HostKeyReceived += (_, e) =>
         {
-            presentedFingerprint = SshHostKeyFingerprint.Normalize(e.FingerPrintSHA256);
+            var presentedFingerprint = SshHostKeyFingerprint.Normalize(e.FingerPrintSHA256);
             e.CanTrust = trustedFingerprints.Any(
                 trusted => SshHostKeyFingerprint.Matches(trusted, presentedFingerprint));
+            untrustedFingerprint = e.CanTrust ? null : presentedFingerprint;
         };
 
         try
@@ -91,19 +92,19 @@ public sealed class SftpClientFactory : ISftpClientFactory
         {
             client.Dispose();
 
-            if (presentedFingerprint is not null)
+            if (untrustedFingerprint is not null)
             {
                 var mismatch = new SshHostKeyMismatchException(
                     profile.Host,
                     profile.Port,
                     trustedFingerprints,
-                    presentedFingerprint);
+                    untrustedFingerprint);
                 _logger.LogError(
                     mismatch,
                     "Rejected SFTP host {Host}:{Port}: observed host key fingerprint {ObservedFingerprint} is not trusted",
                     profile.Host,
                     profile.Port,
-                    presentedFingerprint);
+                    untrustedFingerprint);
                 throw mismatch;
             }
 

--- a/SporeSync.Business/Sftp/SftpClientFactory.cs
+++ b/SporeSync.Business/Sftp/SftpClientFactory.cs
@@ -73,29 +73,14 @@ public sealed class SftpClientFactory : ISftpClientFactory
             OperationTimeout = TimeSpan.FromSeconds(_options.SftpOperationTimeoutSeconds)
         };
 
-        var pinnedFingerprint = profile.HostKeyFingerprintSha256;
+        var trustedFingerprints = profile.TrustedHostKeyFingerprintsSha256;
         string? presentedFingerprint = null;
-        string? mismatchFingerprint = null;
 
         client.HostKeyReceived += (_, e) =>
         {
             presentedFingerprint = SshHostKeyFingerprint.Normalize(e.FingerPrintSHA256);
-
-            if (string.IsNullOrWhiteSpace(pinnedFingerprint))
-            {
-                // Trust-on-first-use: accept and pin after the connection succeeds.
-                e.CanTrust = true;
-                return;
-            }
-
-            if (SshHostKeyFingerprint.Matches(pinnedFingerprint, presentedFingerprint))
-            {
-                e.CanTrust = true;
-                return;
-            }
-
-            mismatchFingerprint = presentedFingerprint;
-            e.CanTrust = false;
+            e.CanTrust = trustedFingerprints.Any(
+                trusted => SshHostKeyFingerprint.Matches(trusted, presentedFingerprint));
         };
 
         try
@@ -106,20 +91,19 @@ public sealed class SftpClientFactory : ISftpClientFactory
         {
             client.Dispose();
 
-            if (mismatchFingerprint is not null)
+            if (presentedFingerprint is not null)
             {
                 var mismatch = new SshHostKeyMismatchException(
                     profile.Host,
                     profile.Port,
-                    pinnedFingerprint!,
-                    mismatchFingerprint);
+                    trustedFingerprints,
+                    presentedFingerprint);
                 _logger.LogError(
                     mismatch,
-                    "Rejected SFTP host {Host}:{Port}: host key fingerprint {ActualFingerprint} does not match pinned fingerprint {ExpectedFingerprint}",
+                    "Rejected SFTP host {Host}:{Port}: observed host key fingerprint {ObservedFingerprint} is not trusted",
                     profile.Host,
                     profile.Port,
-                    mismatchFingerprint,
-                    pinnedFingerprint);
+                    presentedFingerprint);
                 throw mismatch;
             }
 
@@ -127,51 +111,7 @@ public sealed class SftpClientFactory : ISftpClientFactory
             throw;
         }
 
-        if (string.IsNullOrWhiteSpace(pinnedFingerprint) && presentedFingerprint is not null)
-        {
-            await PinHostKeyOnFirstUseAsync(profile, presentedFingerprint, cancellationToken);
-        }
-
         return new ConnectedSftpClient(client);
-    }
-
-    private async Task PinHostKeyOnFirstUseAsync(
-        SftpConnectionProfile profile,
-        string fingerprint,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            var pinned = await _profileRepository.TryPinHostKeyFingerprintAsync(
-                profile.Id,
-                fingerprint,
-                cancellationToken);
-
-            if (pinned)
-            {
-                _logger.LogWarning(
-                    "Pinned SSH host key fingerprint {Fingerprint} for SFTP host {Host}:{Port} on first use (profile '{ProfileName}'). Future connections will be rejected if the host key changes.",
-                    fingerprint,
-                    profile.Host,
-                    profile.Port,
-                    profile.Name);
-            }
-            else
-            {
-                _logger.LogInformation(
-                    "Skipped first-use host key pin for SFTP profile '{ProfileName}' because the profile was already pinned or no longer exists.",
-                    profile.Name);
-            }
-        }
-        catch (Exception ex)
-        {
-            // The connection itself succeeded; failing to persist the pin should not fail the sync run.
-            _logger.LogError(
-                ex,
-                "Failed to persist first-use host key fingerprint {Fingerprint} for SFTP profile '{ProfileName}'",
-                fingerprint,
-                profile.Name);
-        }
     }
 
     private sealed class ConnectedSftpClient : IConnectedSftpClient

--- a/SporeSync.Business/Sftp/SshHostKeyMismatchException.cs
+++ b/SporeSync.Business/Sftp/SshHostKeyMismatchException.cs
@@ -9,17 +9,17 @@ public sealed class SshHostKeyMismatchException : Exception
     public SshHostKeyMismatchException(
         string host,
         int port,
-        string expectedFingerprint,
+        IReadOnlyCollection<string> trustedFingerprints,
         string actualFingerprint)
         : base(
             $"SSH host key verification failed for {host}:{port}. " +
-            $"The server presented key fingerprint '{actualFingerprint}' but the connection profile has " +
-            $"'{expectedFingerprint}' pinned. This can indicate a man-in-the-middle attack or a legitimate " +
-            "host key rotation. If the change is expected, update or clear the pinned fingerprint on the profile.")
+            $"The server presented key fingerprint '{actualFingerprint}', which is not trusted by the connection profile. " +
+            "This can indicate a man-in-the-middle attack or a legitimate host key rotation. " +
+            "Verify the key through a trusted channel before updating the profile.")
     {
         Host = host;
         Port = port;
-        ExpectedFingerprint = expectedFingerprint;
+        TrustedFingerprints = trustedFingerprints;
         ActualFingerprint = actualFingerprint;
     }
 
@@ -27,7 +27,7 @@ public sealed class SshHostKeyMismatchException : Exception
 
     public int Port { get; }
 
-    public string ExpectedFingerprint { get; }
+    public IReadOnlyCollection<string> TrustedFingerprints { get; }
 
     public string ActualFingerprint { get; }
 }

--- a/SporeSync.Domain/Interface/ISftpConnectionProfileRepository.cs
+++ b/SporeSync.Domain/Interface/ISftpConnectionProfileRepository.cs
@@ -19,11 +19,6 @@ public interface ISftpConnectionProfileRepository
         SftpConnectionProfile profile,
         CancellationToken cancellationToken = default);
 
-    Task<bool> TryPinHostKeyFingerprintAsync(
-        Guid id,
-        string fingerprintSha256,
-        CancellationToken cancellationToken = default);
-
     Task<bool> HasAnyEncryptedSecretsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/SporeSync.Domain/Model/SftpConnectionProfile.cs
+++ b/SporeSync.Domain/Model/SftpConnectionProfile.cs
@@ -19,11 +19,10 @@ public sealed class SftpConnectionProfile
     public string? EncryptedPrivateKeyPassphrase { get; init; }
 
     /// <summary>
-    /// Pinned SSH host key fingerprint in canonical "SHA256:&lt;base64&gt;" form.
-    /// When set, connections are rejected unless the server presents a matching key.
-    /// When null, the fingerprint is captured and pinned on first use.
+    /// Trusted SSH host key fingerprints in canonical "SHA256:&lt;base64&gt;" form.
+    /// Connections are rejected unless the server presents one of these keys.
     /// </summary>
-    public string? HostKeyFingerprintSha256 { get; init; }
+    public IReadOnlyList<string> TrustedHostKeyFingerprintsSha256 { get; set; } = [];
 
     public bool IsDefault { get; init; }
 }

--- a/SporeSync.Domain/Model/UpsertSftpConnectionProfile.cs
+++ b/SporeSync.Domain/Model/UpsertSftpConnectionProfile.cs
@@ -30,11 +30,10 @@ public sealed class UpsertSftpConnectionProfile
     public bool RemovePrivateKeyPassphrase { get; init; }
 
     /// <summary>
-    /// SSH host key fingerprint to pin. Null preserves the currently stored fingerprint,
-    /// an empty/whitespace value clears the pin (re-enabling trust-on-first-use), and a
-    /// non-blank value replaces the pin after normalization.
+    /// Trusted SSH host key fingerprints. Null preserves the currently stored collection;
+    /// an empty collection clears it, causing all connections to fail closed.
     /// </summary>
-    public string? HostKeyFingerprintSha256 { get; init; }
+    public IReadOnlyList<string>? TrustedHostKeyFingerprintsSha256 { get; init; }
 
     public bool IsDefault { get; init; } = true;
 }

--- a/SporeSync.Infrastructure/Migrations/AddTrustedHostKeysMigration.cs
+++ b/SporeSync.Infrastructure/Migrations/AddTrustedHostKeysMigration.cs
@@ -1,0 +1,37 @@
+using FluentMigrator;
+
+namespace SporeSync.Infrastructure.Migrations;
+
+[Migration(202607110009)]
+public sealed class AddTrustedHostKeysMigration : Migration
+{
+    public override void Up()
+    {
+        Execute.Sql("""
+            CREATE TABLE core.sftp_connection_profile_trusted_host_keys (
+                profile_id uuid NOT NULL REFERENCES core.sftp_connection_profiles(id) ON DELETE CASCADE,
+                fingerprint_sha256 varchar(100) NOT NULL,
+                PRIMARY KEY (profile_id, fingerprint_sha256)
+            );
+            INSERT INTO core.sftp_connection_profile_trusted_host_keys (profile_id, fingerprint_sha256)
+            SELECT id, host_key_fingerprint_sha256
+            FROM core.sftp_connection_profiles
+            WHERE host_key_fingerprint_sha256 IS NOT NULL;
+            """);
+    }
+
+    public override void Down()
+    {
+        Execute.Sql("""
+            UPDATE core.sftp_connection_profiles profiles
+            SET host_key_fingerprint_sha256 = keys.fingerprint_sha256
+            FROM (
+                SELECT DISTINCT ON (profile_id) profile_id, fingerprint_sha256
+                FROM core.sftp_connection_profile_trusted_host_keys
+                ORDER BY profile_id, fingerprint_sha256
+            ) keys
+            WHERE profiles.id = keys.profile_id;
+            DROP TABLE core.sftp_connection_profile_trusted_host_keys;
+            """);
+    }
+}

--- a/SporeSync.Infrastructure/Migrations/AddTrustedHostKeysMigration.cs
+++ b/SporeSync.Infrastructure/Migrations/AddTrustedHostKeysMigration.cs
@@ -2,7 +2,7 @@ using FluentMigrator;
 
 namespace SporeSync.Infrastructure.Migrations;
 
-[Migration(202607110009)]
+[Migration(202607110010)]
 public sealed class AddTrustedHostKeysMigration : Migration
 {
     public override void Up()

--- a/SporeSync.Infrastructure/Repository/SftpConnectionProfileRepository.cs
+++ b/SporeSync.Infrastructure/Repository/SftpConnectionProfileRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
+using NpgsqlTypes;
 using SporeSync.Domain.Interface;
 using SporeSync.Domain.Model;
 using SporeSync.Infrastructure.Logging;
@@ -12,7 +13,6 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
     private const string OpGetAllProfiles = "GetAllProfiles";
     private const string OpGetProfileById = "GetProfileById";
     private const string OpUpsertProfile = "UpsertProfile";
-    private const string OpTryPinHostKeyFingerprint = "TryPinHostKeyFingerprint";
     private const string OpHasAnyEncryptedSecrets = "HasAnyEncryptedSecrets";
     private const string OpDeleteProfile = "DeleteProfile";
 
@@ -47,7 +47,7 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
         await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
         await using var command = new NpgsqlCommand(sql, connection);
 
-        return await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpGetAllProfiles,
+        var profiles = await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpGetAllProfiles,
             async reader =>
             {
                 var profiles = new List<SftpConnectionProfile>();
@@ -57,6 +57,8 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
                 }
                 return profiles;
             }, cancellationToken);
+        await LoadTrustedHostKeysAsync(connection, profiles, cancellationToken);
+        return profiles;
     }
 
     public async Task<SftpConnectionProfile?> GetByIdAsync(
@@ -81,7 +83,7 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("id", id);
 
-        return await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpGetProfileById,
+        var profile = await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpGetProfileById,
             async reader =>
             {
                 if (!await reader.ReadAsync(cancellationToken))
@@ -90,6 +92,11 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
                 }
                 return ReadProfile(reader);
             }, cancellationToken);
+        if (profile is not null)
+        {
+            await LoadTrustedHostKeysAsync(connection, [profile], cancellationToken);
+        }
+        return profile;
     }
 
     public async Task<SftpConnectionProfile> UpsertAsync(
@@ -121,7 +128,8 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
             """;
 
         await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
-        await using var command = new NpgsqlCommand(sql, connection);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+        await using var command = new NpgsqlCommand(sql, connection, transaction);
         command.Parameters.AddWithValue("id", profile.Id);
         command.Parameters.AddWithValue("name", profile.Name);
         command.Parameters.AddWithValue("host", profile.Host);
@@ -134,10 +142,10 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
             (object?)profile.EncryptedPrivateKeyPassphrase ?? DBNull.Value);
         command.Parameters.AddWithValue(
             "host_key_fingerprint_sha256",
-            (object?)profile.HostKeyFingerprintSha256 ?? DBNull.Value);
+            DBNull.Value);
         command.Parameters.AddWithValue("is_default", profile.IsDefault);
 
-        return await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpUpsertProfile,
+        var saved = await DbCommandLogger.ExecuteReaderAsync(_logger, command, OpUpsertProfile,
             async reader =>
             {
                 if (!await reader.ReadAsync(cancellationToken))
@@ -146,38 +154,21 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
                 }
                 return ReadProfile(reader);
             }, cancellationToken);
-    }
 
-    public async Task<bool> TryPinHostKeyFingerprintAsync(
-        Guid id,
-        string fingerprintSha256,
-        CancellationToken cancellationToken = default)
-    {
-        const string sql = """
-            WITH pinned AS (
-                UPDATE core.sftp_connection_profiles
-                SET host_key_fingerprint_sha256 = @host_key_fingerprint_sha256,
-                    updated_at = now()
-                WHERE id = @id
-                  AND host_key_fingerprint_sha256 IS NULL
-                RETURNING 1
-            )
-            SELECT EXISTS(SELECT 1 FROM pinned);
-            """;
-
-        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
-        await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("id", id);
-        command.Parameters.AddWithValue("host_key_fingerprint_sha256", fingerprintSha256);
-
-        var pinned = await DbCommandLogger.ExecuteScalarAsync(
-            _logger,
-            command,
-            OpTryPinHostKeyFingerprint,
-            cancellationToken);
-
-        return (bool)(pinned
-            ?? throw new InvalidOperationException("Host key pin update did not return a value."));
+        await using var replaceKeys = new NpgsqlCommand("""
+            DELETE FROM core.sftp_connection_profile_trusted_host_keys WHERE profile_id = @id;
+            INSERT INTO core.sftp_connection_profile_trusted_host_keys (profile_id, fingerprint_sha256)
+            SELECT @id, unnest(@fingerprints);
+            """, connection, transaction);
+        replaceKeys.Parameters.AddWithValue("id", profile.Id);
+        replaceKeys.Parameters.AddWithValue(
+            "fingerprints",
+            NpgsqlDbType.Array | NpgsqlDbType.Varchar,
+            profile.TrustedHostKeyFingerprintsSha256.ToArray());
+        await replaceKeys.ExecuteNonQueryAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+        saved.TrustedHostKeyFingerprintsSha256 = profile.TrustedHostKeyFingerprintsSha256;
+        return saved;
     }
 
     public async Task<bool> HasAnyEncryptedSecretsAsync(CancellationToken cancellationToken = default)
@@ -236,8 +227,37 @@ public sealed class SftpConnectionProfileRepository : ISftpConnectionProfileRepo
             EncryptedPassword = reader.IsDBNull(5) ? null : reader.GetString(5),
             EncryptedPrivateKey = reader.IsDBNull(6) ? null : reader.GetString(6),
             EncryptedPrivateKeyPassphrase = reader.IsDBNull(7) ? null : reader.GetString(7),
-            HostKeyFingerprintSha256 = reader.IsDBNull(8) ? null : reader.GetString(8),
             IsDefault = reader.GetBoolean(9)
         };
+    }
+
+    private static async Task LoadTrustedHostKeysAsync(
+        NpgsqlConnection connection,
+        IReadOnlyCollection<SftpConnectionProfile> profiles,
+        CancellationToken cancellationToken)
+    {
+        if (profiles.Count == 0)
+        {
+            return;
+        }
+
+        await using var command = new NpgsqlCommand("""
+            SELECT profile_id, fingerprint_sha256
+            FROM core.sftp_connection_profile_trusted_host_keys
+            WHERE profile_id = ANY(@profile_ids)
+            ORDER BY fingerprint_sha256;
+            """, connection);
+        command.Parameters.AddWithValue("profile_ids", profiles.Select(profile => profile.Id).ToArray());
+        var byId = profiles.ToDictionary(profile => profile.Id);
+        var keys = profiles.ToDictionary(profile => profile.Id, _ => new List<string>());
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            keys[reader.GetGuid(0)].Add(reader.GetString(1));
+        }
+        foreach (var (id, fingerprints) in keys)
+        {
+            byId[id].TrustedHostKeyFingerprintsSha256 = fingerprints;
+        }
     }
 }

--- a/SporeSync.Web/ClientApp/src/api/types.ts
+++ b/SporeSync.Web/ClientApp/src/api/types.ts
@@ -83,7 +83,7 @@ export interface SftpConnectionProfile {
   hasPassword: boolean;
   hasPrivateKey: boolean;
   hasPrivateKeyPassphrase: boolean;
-  hostKeyFingerprintSha256: string | null;
+  trustedHostKeyFingerprintsSha256: string[];
   isDefault: boolean;
 }
 
@@ -97,8 +97,8 @@ export interface UpsertSftpConnectionProfile {
   privateKey?: string | null;
   privateKeyPassphrase?: string | null;
   removePrivateKeyPassphrase: boolean;
-  // Null preserves the stored pin; an empty string clears it (trust-on-first-use).
-  hostKeyFingerprintSha256?: string | null;
+  // Null preserves stored fingerprints; an empty array makes connections fail closed.
+  trustedHostKeyFingerprintsSha256?: string[] | null;
   isDefault: boolean;
 }
 

--- a/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
@@ -831,8 +831,8 @@ function ProfileForm({
   const [privateKeyPassphrase, setPrivateKeyPassphrase] = useState("");
   const [removePrivateKeyPassphrase, setRemovePrivateKeyPassphrase] =
     useState(false);
-  const [hostKeyFingerprint, setHostKeyFingerprint] = useState(
-    profile?.hostKeyFingerprintSha256 ?? "",
+  const [hostKeyFingerprints, setHostKeyFingerprints] = useState(
+    profile?.trustedHostKeyFingerprintsSha256.join("\n") ?? "",
   );
   const [isDefault, setIsDefault] = useState(profile?.isDefault ?? true);
   const preservesSelectedCredential =
@@ -840,7 +840,11 @@ function ProfileForm({
   const scanMutation = useMutation({
     mutationFn: () => api.scanHostKey(host.trim(), port),
     onSuccess: (result) => {
-      setHostKeyFingerprint(result.fingerprintSha256);
+      setHostKeyFingerprints((current) =>
+        [...current.split(/\s+/).filter(Boolean), result.fingerprintSha256]
+          .filter((value, index, values) => values.indexOf(value) === index)
+          .join("\n"),
+      );
     },
   });
   const validation = useMemo(() => {
@@ -890,9 +894,9 @@ function ProfileForm({
               ? privateKeyPassphrase
               : null,
             removePrivateKeyPassphrase,
-            // The form always knows the current pin, so submit it verbatim;
-            // an empty value clears the pin and re-enables trust-on-first-use.
-            hostKeyFingerprintSha256: hostKeyFingerprint.trim(),
+            trustedHostKeyFingerprintsSha256: hostKeyFingerprints
+              .split(/\s+/)
+              .filter(Boolean),
             isDefault,
           });
         }
@@ -1036,13 +1040,13 @@ function ProfileForm({
           </>
         )}
         <div className="md:col-span-2">
-          <Field label="Pinned host key fingerprint (SHA-256)">
+          <Field label="Trusted host key fingerprints (SHA-256, one per line)">
             <div className="flex gap-2">
-              <input
-                className={`${inputClass} font-mono text-xs`}
-                placeholder="SHA256:…  (blank = trust and pin on first connection)"
-                value={hostKeyFingerprint}
-                onChange={(event) => setHostKeyFingerprint(event.target.value)}
+              <textarea
+                className={`${inputClass} min-h-20 py-2 font-mono text-xs`}
+                placeholder="SHA256:…"
+                value={hostKeyFingerprints}
+                onChange={(event) => setHostKeyFingerprints(event.target.value)}
               />
               <Button
                 type="button"
@@ -1068,10 +1072,10 @@ function ProfileForm({
             </p>
           )}
           <p className="mt-2 text-xs text-muted-foreground">
-            Connections are rejected when the server key does not match the
-            pinned fingerprint. Leave blank to pin automatically on first
-            connection; clear the field if the server host key legitimately
-            changed.
+            Connections are rejected unless the server key matches one of these
+            fingerprints. A blank list rejects every connection. During
+            rotation, keep both old and new fingerprints until the old key is
+            retired.
           </p>
         </div>
         <label className="flex items-center gap-2 pt-6 text-sm">
@@ -1185,7 +1189,7 @@ function SecretIndicators({ profile }: { profile: SftpConnectionProfile }) {
     { label: "Key", enabled: profile.hasPrivateKey },
     { label: "Passphrase", enabled: profile.hasPrivateKeyPassphrase },
   ];
-  const hostKeyPinned = Boolean(profile.hostKeyFingerprintSha256);
+  const hostKeyPinned = profile.trustedHostKeyFingerprintsSha256.length > 0;
   return (
     <div className="flex flex-wrap gap-1">
       {items.map((item) => (
@@ -1200,8 +1204,8 @@ function SecretIndicators({ profile }: { profile: SftpConnectionProfile }) {
       <span
         title={
           hostKeyPinned
-            ? `Pinned host key: ${profile.hostKeyFingerprintSha256}`
-            : "Host key not pinned yet; it will be pinned on first connection."
+            ? `Trusted host keys: ${profile.trustedHostKeyFingerprintsSha256.join(", ")}`
+            : "No trusted host key; connections are blocked."
         }
         className={
           hostKeyPinned

--- a/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
+++ b/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
@@ -182,7 +182,7 @@ public sealed class SftpConnectionProfilesController : ControllerBase
             PrivateKey = request.PrivateKey,
             PrivateKeyPassphrase = request.PrivateKeyPassphrase,
             RemovePrivateKeyPassphrase = request.RemovePrivateKeyPassphrase,
-            HostKeyFingerprintSha256 = request.HostKeyFingerprintSha256,
+            TrustedHostKeyFingerprintsSha256 = request.TrustedHostKeyFingerprintsSha256,
             IsDefault = request.IsDefault
         };
     }
@@ -210,7 +210,7 @@ public sealed class SftpConnectionProfilesController : ControllerBase
             profile.EncryptedPassword is not null,
             profile.EncryptedPrivateKey is not null,
             profile.EncryptedPrivateKeyPassphrase is not null,
-            profile.HostKeyFingerprintSha256,
+            profile.TrustedHostKeyFingerprintsSha256,
             profile.IsDefault);
     }
 }

--- a/SporeSync.Web/DTO/SftpConnectionProfileResponse.cs
+++ b/SporeSync.Web/DTO/SftpConnectionProfileResponse.cs
@@ -10,5 +10,5 @@ public sealed record SftpConnectionProfileResponse(
     bool HasPassword,
     bool HasPrivateKey,
     bool HasPrivateKeyPassphrase,
-    string? HostKeyFingerprintSha256,
+    IReadOnlyList<string> TrustedHostKeyFingerprintsSha256,
     bool IsDefault);

--- a/SporeSync.Web/DTO/UpsertSftpConnectionProfileRequest.cs
+++ b/SporeSync.Web/DTO/UpsertSftpConnectionProfileRequest.cs
@@ -29,7 +29,6 @@ public sealed record UpsertSftpConnectionProfileRequest(
 
     bool RemovePrivateKeyPassphrase = false,
 
-    [param: MaxLength(100)]
-    string? HostKeyFingerprintSha256 = null,
+    IReadOnlyList<string>? TrustedHostKeyFingerprintsSha256 = null,
 
     bool IsDefault = true);


### PR DESCRIPTION
Closes #20

## Summary
- replace trust-on-first-use with fail-closed SHA-256 host-key verification
- store multiple trusted fingerprints per profile for planned key rotation and migrate existing single pins
- expose editable trust lists in the admin UI while keeping host-key scans observation-only
- document the upgrade policy for profiles without an existing pin
- cover matching, missing/mismatched, and rotating keys against the real SFTP test container

## Validation
- `dotnet build SporeSync.sln` — passed (0 errors; existing package warnings)
- `dotnet test SporeSync.sln` — passed (259/259)
- `npm run biome:check` from `SporeSync.Web/ClientApp` — passed
- `npm test` from `SporeSync.Web/ClientApp` — passed (27/27)