### PR TITLE
Add Test Connection for SFTP profiles

### DIFF
--- a/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
+++ b/SporeSync.Business.Tests/RepositoryIntegrationTests.cs
@@ -1153,8 +1153,7 @@ public sealed class RepositoryIntegrationTests : IClassFixture<RepositoryTestcon
 
         var profile = await profileRepository.UpsertAsync(CreateProfile());
         var job = await jobRepository.UpsertAsync(CreateJob(profile.Id));
-        var run = await runRepository.TryCreateAsync(job.Id);
-        Assert.NotNull(run);
+        var run = Assert.IsType<SporeSyncRun>(await runRepository.TryCreateAsync(job.Id));
 
         Assert.Equal(SafeDeleteSporeSyncJobResult.ActiveRunExists, await jobRepository.SafeDeleteAsync(job.Id));
         Assert.NotNull(await jobRepository.GetByIdAsync(job.Id));

--- a/SporeSync.Business.Tests/Sftp/SftpConnectionTestIntegrationTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpConnectionTestIntegrationTests.cs
@@ -24,8 +24,12 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
     public async Task UnsavedConfiguration_ConnectsAndChecksSourcePath()
     {
         var (service, _) = CreateService();
+        var fingerprint = await TrustedFingerprintAsync();
 
-        var result = await TestAsync(service, PasswordRequest(SftpTestcontainerFixture.Password, "/upload"));
+        var result = await TestAsync(service, PasswordRequest(
+            SftpTestcontainerFixture.Password,
+            "/upload",
+            fingerprint));
 
         Assert.True(result.Success);
         Assert.Null(result.FailureType);
@@ -35,14 +39,16 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
     public async Task Failures_AreCategorizedWithoutReturningServerExceptionDetails()
     {
         var (service, _) = CreateService();
+        var fingerprint = await TrustedFingerprintAsync();
 
-        var authentication = await TestAsync(service, PasswordRequest("wrong-password"));
+        var authentication = await TestAsync(service, PasswordRequest("wrong-password", fingerprint: fingerprint));
         var hostKey = await TestAsync(service, PasswordRequest(
             SftpTestcontainerFixture.Password,
             fingerprint: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
         var path = await TestAsync(service, PasswordRequest(
             SftpTestcontainerFixture.Password,
-            "/upload/does-not-exist"));
+            "/upload/does-not-exist",
+            fingerprint));
 
         Assert.Equal("authentication", authentication.FailureType);
         Assert.Equal("host_key", hostKey.FailureType);
@@ -55,6 +61,7 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
     {
         var (service, repository) = CreateService();
         var protector = repository.Protector;
+        var fingerprint = await TrustedFingerprintAsync();
         var profile = new SftpConnectionProfile
         {
             Id = Guid.NewGuid(),
@@ -63,13 +70,18 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
             Port = _sftp.Port,
             Username = SftpTestcontainerFixture.Username,
             EncryptedPassword = protector.Protect(SftpTestcontainerFixture.Password),
+            TrustedHostKeyFingerprintsSha256 = [fingerprint],
             IsDefault = false
         };
         repository.Profile = profile;
 
-        var reused = await TestAsync(service, PasswordRequest(null, profileId: profile.Id));
+        var reused = await TestAsync(service, PasswordRequest(
+            null,
+            fingerprint: fingerprint,
+            profileId: profile.Id));
         var replacement = await TestAsync(service, PasswordRequest(
             SftpTestcontainerFixture.Password,
+            fingerprint: fingerprint,
             profileId: profile.Id));
 
         Assert.True(reused.Success);
@@ -100,6 +112,15 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
         Assert.False(result.Success);
         Assert.Equal("connection", result.FailureType);
         Assert.Equal("The SFTP connection or operation timed out.", result.Message);
+    }
+
+    private async Task<string> TrustedFingerprintAsync()
+    {
+        var scanner = new SshHostKeyScanner(
+            Options.Create(new SporeSyncOptions { SftpConnectionTimeoutSeconds = 10 }),
+            NullLogger<SshHostKeyScanner>.Instance);
+
+        return (await scanner.ScanAsync(_sftp.Host, _sftp.Port)).FingerprintSha256;
     }
 
     private async Task<SftpConnectionTestResult> TestAsync(

--- a/SporeSync.Business.Tests/Sftp/SftpConnectionTestIntegrationTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpConnectionTestIntegrationTests.cs
@@ -189,5 +189,10 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
 
         public Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default) =>
             Task.FromResult(false);
+
+        public Task<SafeDeleteSftpConnectionProfileResult> SafeDeleteAsync(
+            Guid id,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(SafeDeleteSftpConnectionProfileResult.NotFound);
     }
 }

--- a/SporeSync.Business.Tests/Sftp/SftpConnectionTestIntegrationTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpConnectionTestIntegrationTests.cs
@@ -1,0 +1,166 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SporeSync.Business.Interface;
+using SporeSync.Business.Security;
+using SporeSync.Business.Service;
+using SporeSync.Business.Sftp;
+using SporeSync.Domain.Interface;
+using SporeSync.Domain.Model;
+
+namespace SporeSync.Business.Tests.Sftp;
+
+public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestcontainerFixture>
+{
+    private readonly SftpTestcontainerFixture _sftp;
+
+    public SftpConnectionTestIntegrationTests(SftpTestcontainerFixture sftp)
+    {
+        _sftp = sftp;
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task UnsavedConfiguration_ConnectsAndChecksSourcePath()
+    {
+        var (service, _) = CreateService();
+
+        var result = await TestAsync(service, PasswordRequest(SftpTestcontainerFixture.Password, "/upload"));
+
+        Assert.True(result.Success);
+        Assert.Null(result.FailureType);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Failures_AreCategorizedWithoutReturningServerExceptionDetails()
+    {
+        var (service, _) = CreateService();
+
+        var authentication = await TestAsync(service, PasswordRequest("wrong-password"));
+        var hostKey = await TestAsync(service, PasswordRequest(
+            SftpTestcontainerFixture.Password,
+            fingerprint: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+        var path = await TestAsync(service, PasswordRequest(
+            SftpTestcontainerFixture.Password,
+            "/upload/does-not-exist"));
+
+        Assert.Equal("authentication", authentication.FailureType);
+        Assert.Equal("host_key", hostKey.FailureType);
+        Assert.Equal("path", path.FailureType);
+        Assert.DoesNotContain("wrong-password", authentication.Message);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task BlankSecrets_ReuseStoredCredential_AndReplacementIsNotPersisted()
+    {
+        var (service, repository) = CreateService();
+        var protector = repository.Protector;
+        var profile = new SftpConnectionProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "stored",
+            Host = _sftp.Host,
+            Port = _sftp.Port,
+            Username = SftpTestcontainerFixture.Username,
+            EncryptedPassword = protector.Protect(SftpTestcontainerFixture.Password),
+            IsDefault = false
+        };
+        repository.Profile = profile;
+
+        var reused = await TestAsync(service, PasswordRequest(null, profileId: profile.Id));
+        var replacement = await TestAsync(service, PasswordRequest(
+            SftpTestcontainerFixture.Password,
+            profileId: profile.Id));
+
+        Assert.True(reused.Success);
+        Assert.True(replacement.Success);
+        Assert.Same(profile, repository.Profile);
+        Assert.Equal(SftpTestcontainerFixture.Password, protector.Unprotect(profile.EncryptedPassword!));
+        Assert.Equal(0, repository.UpsertCount);
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task Cancellation_IsPropagated()
+    {
+        var (service, _) = CreateService();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.TestAsync(PasswordRequest(SftpTestcontainerFixture.Password), cancellation.Token));
+    }
+
+    private async Task<SftpConnectionTestResult> TestAsync(
+        ISftpConnectionTestService service,
+        SftpConnectionTestRequest request)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+        return await service.TestAsync(request, timeout.Token);
+    }
+
+    private SftpConnectionTestRequest PasswordRequest(
+        string? password,
+        string? sourcePath = null,
+        string? fingerprint = null,
+        Guid? profileId = null) => new()
+    {
+        ProfileId = profileId,
+        Host = _sftp.Host,
+        Port = _sftp.Port,
+        Username = SftpTestcontainerFixture.Username,
+        Password = password,
+        HostKeyFingerprintSha256 = fingerprint,
+        SourcePath = sourcePath
+    };
+
+    private static (SftpConnectionTestService Service, FakeProfileRepository Repository) CreateService()
+    {
+        var keyProvider = new EncryptionKeyProvider();
+        keyProvider.Initialize(RandomNumberGenerator.GetBytes(32));
+        var protector = new SecretProtector(keyProvider);
+        var repository = new FakeProfileRepository(protector);
+        var options = Options.Create(new SporeSyncOptions
+        {
+            SftpConnectionTimeoutSeconds = 10,
+            SftpOperationTimeoutSeconds = 10
+        });
+        var factory = new SftpClientFactory(
+            repository,
+            protector,
+            options,
+            NullLogger<SftpClientFactory>.Instance);
+        return (new SftpConnectionTestService(
+            repository,
+            factory,
+            protector,
+            NullLogger<SftpConnectionTestService>.Instance), repository);
+    }
+
+    private sealed class FakeProfileRepository(ISecretProtector protector) : ISftpConnectionProfileRepository
+    {
+        public ISecretProtector Protector { get; } = protector;
+        public SftpConnectionProfile? Profile { get; set; }
+        public int UpsertCount { get; private set; }
+
+        public Task<SftpConnectionProfile?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(Profile?.Id == id ? Profile : null);
+
+        public Task<SftpConnectionProfile> UpsertAsync(SftpConnectionProfile profile, CancellationToken cancellationToken = default)
+        {
+            UpsertCount++;
+            Profile = profile;
+            return Task.FromResult(profile);
+        }
+
+        public Task<IReadOnlyCollection<SftpConnectionProfile>> GetAllAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyCollection<SftpConnectionProfile>>(Profile is null ? [] : [Profile]);
+
+        public Task<bool> TryPinHostKeyFingerprintAsync(Guid id, string fingerprintSha256, CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+
+        public Task<bool> HasAnyEncryptedSecretsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(Profile?.EncryptedPassword is not null);
+
+        public Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+    }
+}

--- a/SporeSync.Business.Tests/Sftp/SftpConnectionTestIntegrationTests.cs
+++ b/SporeSync.Business.Tests/Sftp/SftpConnectionTestIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Renci.SshNet.Common;
 using SporeSync.Business.Interface;
 using SporeSync.Business.Security;
 using SporeSync.Business.Service;
@@ -89,6 +90,18 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
             service.TestAsync(PasswordRequest(SftpTestcontainerFixture.Password), cancellation.Token));
     }
 
+    [Fact]
+    public async Task OperationTimeout_IsClassifiedAsConnectionFailure()
+    {
+        var (service, _) = CreateService(new TimeoutSftpClientFactory());
+
+        var result = await TestAsync(service, PasswordRequest(SftpTestcontainerFixture.Password));
+
+        Assert.False(result.Success);
+        Assert.Equal("connection", result.FailureType);
+        Assert.Equal("The SFTP connection or operation timed out.", result.Message);
+    }
+
     private async Task<SftpConnectionTestResult> TestAsync(
         ISftpConnectionTestService service,
         SftpConnectionTestRequest request)
@@ -112,7 +125,8 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
         SourcePath = sourcePath
     };
 
-    private static (SftpConnectionTestService Service, FakeProfileRepository Repository) CreateService()
+    private static (SftpConnectionTestService Service, FakeProfileRepository Repository) CreateService(
+        ISftpClientFactory? factory = null)
     {
         var keyProvider = new EncryptionKeyProvider();
         keyProvider.Initialize(RandomNumberGenerator.GetBytes(32));
@@ -123,7 +137,7 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
             SftpConnectionTimeoutSeconds = 10,
             SftpOperationTimeoutSeconds = 10
         });
-        var factory = new SftpClientFactory(
+        factory ??= new SftpClientFactory(
             repository,
             protector,
             options,
@@ -133,6 +147,19 @@ public sealed class SftpConnectionTestIntegrationTests : IClassFixture<SftpTestc
             factory,
             protector,
             NullLogger<SftpConnectionTestService>.Instance), repository);
+    }
+
+    private sealed class TimeoutSftpClientFactory : ISftpClientFactory
+    {
+        public Task<IConnectedSftpClient> ConnectAsync(
+            Guid connectionProfileId,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IConnectedSftpClient> ConnectAsync(
+            SftpConnectionProfile profile,
+            CancellationToken cancellationToken = default) =>
+            throw new SshOperationTimeoutException("secret-bearing provider detail");
     }
 
     private sealed class FakeProfileRepository(ISecretProtector protector) : ISftpConnectionProfileRepository

--- a/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
@@ -155,8 +155,10 @@ public sealed class SftpConnectionProfilesControllerTests
         22,
         "user",
         "password",
+        "password",
         null,
         null,
+        false,
         null,
         null);
 

--- a/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
@@ -174,6 +174,7 @@ public sealed class SftpConnectionProfilesControllerTests
         null,
         false,
         null,
+        null,
         null);
 
     private sealed class FakeHostKeyScanner : ISshHostKeyScanner

--- a/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
@@ -42,7 +42,7 @@ public sealed class SftpConnectionProfilesControllerTests
         var controller = CreateController(
             testResult: new SftpConnectionTestResult { ProfileFound = false });
 
-        var result = await controller.Test(Guid.NewGuid(), CancellationToken.None);
+        var result = await controller.Test(TestRequest(), CancellationToken.None);
 
         Assert.IsType<NotFoundResult>(result.Result);
     }
@@ -58,7 +58,7 @@ public sealed class SftpConnectionProfilesControllerTests
                 DurationMs = 42
             });
 
-        var result = await controller.Test(Guid.NewGuid(), CancellationToken.None);
+        var result = await controller.Test(TestRequest(), CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<SftpConnectionTestResponse>(okResult.Value);
@@ -74,15 +74,17 @@ public sealed class SftpConnectionProfilesControllerTests
             {
                 ProfileFound = true,
                 Success = false,
-                ErrorMessage = "Permission denied (password)."
+                FailureType = "authentication",
+                Message = "Authentication failed. Check the username and credentials."
             });
 
-        var result = await controller.Test(Guid.NewGuid(), CancellationToken.None);
+        var result = await controller.Test(TestRequest(), CancellationToken.None);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<SftpConnectionTestResponse>(okResult.Value);
         Assert.False(response.Success);
-        Assert.Equal("Permission denied (password).", response.Message);
+        Assert.Equal("authentication", response.FailureType);
+        Assert.Equal("Authentication failed. Check the username and credentials.", response.Message);
     }
 
     [Fact]
@@ -147,6 +149,17 @@ public sealed class SftpConnectionProfilesControllerTests
             removePassphrase);
     }
 
+    private static TestSftpConnectionRequest TestRequest() => new(
+        null,
+        "sftp.example.test",
+        22,
+        "user",
+        "password",
+        null,
+        null,
+        null,
+        null);
+
     private sealed class FakeHostKeyScanner : ISshHostKeyScanner
     {
         public Task<SshHostKeyScanResult> ScanAsync(string host, int port, CancellationToken cancellationToken = default)
@@ -157,7 +170,9 @@ public sealed class SftpConnectionProfilesControllerTests
     {
         public required SftpConnectionTestResult Result { get; init; }
 
-        public Task<SftpConnectionTestResult> TestAsync(Guid profileId, CancellationToken cancellationToken = default)
+        public Task<SftpConnectionTestResult> TestAsync(
+            SftpConnectionTestRequest request,
+            CancellationToken cancellationToken = default)
             => Task.FromResult(Result);
     }
 

--- a/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionProfilesControllerTests.cs
@@ -48,6 +48,20 @@ public sealed class SftpConnectionProfilesControllerTests
     }
 
     [Fact]
+    public async Task Test_ReturnsValidationProblem_WhenAuthenticationMethodIsInvalid()
+    {
+        var controller = CreateController();
+
+        var result = await controller.Test(TestRequest(authenticationMethod: "unsupported"), CancellationToken.None);
+
+        var objectResult = Assert.IsType<ObjectResult>(result.Result);
+        var problem = Assert.IsType<ValidationProblemDetails>(objectResult.Value);
+        Assert.Equal(
+            "Authentication method must be either 'password' or 'privateKey'.",
+            problem.Errors[string.Empty].Single());
+    }
+
+    [Fact]
     public async Task Test_ReturnsSuccessResponse_WhenConnectionSucceeds()
     {
         var controller = CreateController(
@@ -149,12 +163,12 @@ public sealed class SftpConnectionProfilesControllerTests
             removePassphrase);
     }
 
-    private static TestSftpConnectionRequest TestRequest() => new(
+    private static TestSftpConnectionRequest TestRequest(string authenticationMethod = "password") => new(
         null,
         "sftp.example.test",
         22,
         "user",
-        "password",
+        authenticationMethod,
         "password",
         null,
         null,

--- a/SporeSync.Business.Tests/SftpConnectionTestServiceTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionTestServiceTests.cs
@@ -1,0 +1,118 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging.Abstractions;
+using SporeSync.Business.Interface;
+using SporeSync.Business.Security;
+using SporeSync.Business.Service;
+using SporeSync.Business.Sftp;
+using SporeSync.Domain.Interface;
+using SporeSync.Domain.Model;
+
+namespace SporeSync.Business.Tests;
+
+public sealed class SftpConnectionTestServiceTests
+{
+    [Theory]
+    [InlineData(SftpAuthenticationMethod.Password)]
+    [InlineData(SftpAuthenticationMethod.PrivateKey)]
+    public async Task ExistingProfile_UsesOnlyTheSelectedAuthenticationCredential(
+        SftpAuthenticationMethod authenticationMethod)
+    {
+        var keyProvider = new EncryptionKeyProvider();
+        keyProvider.Initialize(RandomNumberGenerator.GetBytes(32));
+        var protector = new SecretProtector(keyProvider);
+        var stored = new SftpConnectionProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "stored",
+            Host = "sftp.example.test",
+            Port = 22,
+            Username = "sync-user",
+            EncryptedPassword = protector.Protect("stored-password"),
+            EncryptedPrivateKey = protector.Protect("stored-private-key"),
+            EncryptedPrivateKeyPassphrase = protector.Protect("stored-passphrase"),
+            IsDefault = false
+        };
+        var repository = new FakeProfileRepository(stored);
+        var factory = new CapturingSftpClientFactory();
+        var service = new SftpConnectionTestService(
+            repository,
+            factory,
+            protector,
+            NullLogger<SftpConnectionTestService>.Instance);
+
+        await service.TestAsync(new SftpConnectionTestRequest
+        {
+            ProfileId = stored.Id,
+            Host = stored.Host,
+            Port = stored.Port,
+            Username = stored.Username,
+            AuthenticationMethod = authenticationMethod,
+            Password = authenticationMethod == SftpAuthenticationMethod.Password ? "replacement-password" : null,
+            PrivateKey = authenticationMethod == SftpAuthenticationMethod.PrivateKey ? "replacement-private-key" : null
+        });
+
+        Assert.NotNull(factory.Profile);
+        if (authenticationMethod == SftpAuthenticationMethod.Password)
+        {
+            Assert.Equal("replacement-password", protector.Unprotect(factory.Profile.EncryptedPassword!));
+            Assert.Null(factory.Profile.EncryptedPrivateKey);
+            Assert.Null(factory.Profile.EncryptedPrivateKeyPassphrase);
+        }
+        else
+        {
+            Assert.Null(factory.Profile.EncryptedPassword);
+            Assert.Equal("replacement-private-key", protector.Unprotect(factory.Profile.EncryptedPrivateKey!));
+            Assert.Equal("stored-passphrase", protector.Unprotect(factory.Profile.EncryptedPrivateKeyPassphrase!));
+        }
+    }
+
+    private sealed class CapturingSftpClientFactory : ISftpClientFactory
+    {
+        public SftpConnectionProfile? Profile { get; private set; }
+
+        public Task<IConnectedSftpClient> ConnectAsync(
+            Guid connectionProfileId,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IConnectedSftpClient> ConnectAsync(
+            SftpConnectionProfile profile,
+            CancellationToken cancellationToken = default)
+        {
+            Profile = profile;
+            throw new System.Net.Sockets.SocketException();
+        }
+    }
+
+    private sealed class FakeProfileRepository(SftpConnectionProfile profile) : ISftpConnectionProfileRepository
+    {
+        public Task<SftpConnectionProfile?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+            Task.FromResult<SftpConnectionProfile?>(profile.Id == id ? profile : null);
+
+        public Task<SftpConnectionProfile> UpsertAsync(
+            SftpConnectionProfile updated,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyCollection<SftpConnectionProfile>> GetAllAsync(
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<bool> TryPinHostKeyFingerprintAsync(
+            Guid id,
+            string fingerprintSha256,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<bool> HasAnyEncryptedSecretsAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<SafeDeleteSftpConnectionProfileResult> SafeDeleteAsync(
+            Guid id,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/SporeSync.Business.Tests/SftpConnectionTestServiceTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionTestServiceTests.cs
@@ -66,6 +66,82 @@ public sealed class SftpConnectionTestServiceTests
         }
     }
 
+    [Fact]
+    public async Task ExistingProfile_WithDifferentEndpoint_DoesNotReuseStoredPassword()
+    {
+        var keyProvider = new EncryptionKeyProvider();
+        keyProvider.Initialize(RandomNumberGenerator.GetBytes(32));
+        var protector = new SecretProtector(keyProvider);
+        var stored = new SftpConnectionProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "stored",
+            Host = "sftp.example.test",
+            Port = 22,
+            Username = "sync-user",
+            EncryptedPassword = protector.Protect("stored-password"),
+            IsDefault = false
+        };
+        var factory = new CapturingSftpClientFactory();
+        var service = new SftpConnectionTestService(
+            new FakeProfileRepository(stored),
+            factory,
+            protector,
+            NullLogger<SftpConnectionTestService>.Instance);
+
+        var result = await service.TestAsync(new SftpConnectionTestRequest
+        {
+            ProfileId = stored.Id,
+            Host = "attacker.example.test",
+            Port = stored.Port,
+            Username = stored.Username,
+            AuthenticationMethod = SftpAuthenticationMethod.Password
+        });
+
+        Assert.False(result.Success);
+        Assert.Equal("authentication", result.FailureType);
+        Assert.Null(factory.Profile);
+    }
+
+    [Fact]
+    public async Task ExistingProfile_WithBlankFingerprint_PreservesStoredFingerprint()
+    {
+        var keyProvider = new EncryptionKeyProvider();
+        keyProvider.Initialize(RandomNumberGenerator.GetBytes(32));
+        var protector = new SecretProtector(keyProvider);
+        const string fingerprint = "SHA256:stored-fingerprint";
+        var stored = new SftpConnectionProfile
+        {
+            Id = Guid.NewGuid(),
+            Name = "stored",
+            Host = "sftp.example.test",
+            Port = 22,
+            Username = "sync-user",
+            EncryptedPassword = protector.Protect("stored-password"),
+            HostKeyFingerprintSha256 = fingerprint,
+            IsDefault = false
+        };
+        var factory = new CapturingSftpClientFactory();
+        var service = new SftpConnectionTestService(
+            new FakeProfileRepository(stored),
+            factory,
+            protector,
+            NullLogger<SftpConnectionTestService>.Instance);
+
+        await service.TestAsync(new SftpConnectionTestRequest
+        {
+            ProfileId = stored.Id,
+            Host = stored.Host,
+            Port = stored.Port,
+            Username = stored.Username,
+            AuthenticationMethod = SftpAuthenticationMethod.Password,
+            HostKeyFingerprintSha256 = ""
+        });
+
+        Assert.NotNull(factory.Profile);
+        Assert.Equal(fingerprint, factory.Profile.HostKeyFingerprintSha256);
+    }
+
     private sealed class CapturingSftpClientFactory : ISftpClientFactory
     {
         public SftpConnectionProfile? Profile { get; private set; }

--- a/SporeSync.Business.Tests/SftpConnectionTestServiceTests.cs
+++ b/SporeSync.Business.Tests/SftpConnectionTestServiceTests.cs
@@ -118,7 +118,7 @@ public sealed class SftpConnectionTestServiceTests
             Port = 22,
             Username = "sync-user",
             EncryptedPassword = protector.Protect("stored-password"),
-            HostKeyFingerprintSha256 = fingerprint,
+            TrustedHostKeyFingerprintsSha256 = [fingerprint],
             IsDefault = false
         };
         var factory = new CapturingSftpClientFactory();
@@ -139,7 +139,7 @@ public sealed class SftpConnectionTestServiceTests
         });
 
         Assert.NotNull(factory.Profile);
-        Assert.Equal(fingerprint, factory.Profile.HostKeyFingerprintSha256);
+        Assert.Equal([fingerprint], factory.Profile.TrustedHostKeyFingerprintsSha256);
     }
 
     private sealed class CapturingSftpClientFactory : ISftpClientFactory

--- a/SporeSync.Business/Interface/ISftpConnectionTestService.cs
+++ b/SporeSync.Business/Interface/ISftpConnectionTestService.cs
@@ -14,6 +14,7 @@ public sealed class SftpConnectionTestRequest
     public string? PrivateKeyPassphrase { get; init; }
     public bool RemovePrivateKeyPassphrase { get; init; }
     public string? HostKeyFingerprintSha256 { get; init; }
+    public IReadOnlyList<string>? TrustedHostKeyFingerprintsSha256 { get; init; }
     public string? SourcePath { get; init; }
 }
 

--- a/SporeSync.Business/Interface/ISftpConnectionTestService.cs
+++ b/SporeSync.Business/Interface/ISftpConnectionTestService.cs
@@ -1,3 +1,5 @@
+using SporeSync.Domain.Model;
+
 namespace SporeSync.Business.Interface;
 
 public sealed class SftpConnectionTestRequest
@@ -6,9 +8,11 @@ public sealed class SftpConnectionTestRequest
     public required string Host { get; init; }
     public int Port { get; init; }
     public required string Username { get; init; }
+    public SftpAuthenticationMethod AuthenticationMethod { get; init; }
     public string? Password { get; init; }
     public string? PrivateKey { get; init; }
     public string? PrivateKeyPassphrase { get; init; }
+    public bool RemovePrivateKeyPassphrase { get; init; }
     public string? HostKeyFingerprintSha256 { get; init; }
     public string? SourcePath { get; init; }
 }

--- a/SporeSync.Business/Interface/ISftpConnectionTestService.cs
+++ b/SporeSync.Business/Interface/ISftpConnectionTestService.cs
@@ -1,12 +1,27 @@
 namespace SporeSync.Business.Interface;
 
+public sealed class SftpConnectionTestRequest
+{
+    public Guid? ProfileId { get; init; }
+    public required string Host { get; init; }
+    public int Port { get; init; }
+    public required string Username { get; init; }
+    public string? Password { get; init; }
+    public string? PrivateKey { get; init; }
+    public string? PrivateKeyPassphrase { get; init; }
+    public string? HostKeyFingerprintSha256 { get; init; }
+    public string? SourcePath { get; init; }
+}
+
 public sealed class SftpConnectionTestResult
 {
     public required bool ProfileFound { get; init; }
 
     public bool Success { get; init; }
 
-    public string? ErrorMessage { get; init; }
+    public string? FailureType { get; init; }
+
+    public string? Message { get; init; }
 
     public long DurationMs { get; init; }
 }
@@ -14,6 +29,6 @@ public sealed class SftpConnectionTestResult
 public interface ISftpConnectionTestService
 {
     Task<SftpConnectionTestResult> TestAsync(
-        Guid profileId,
+        SftpConnectionTestRequest request,
         CancellationToken cancellationToken = default);
 }

--- a/SporeSync.Business/Service/SftpConnectionTestService.cs
+++ b/SporeSync.Business/Service/SftpConnectionTestService.cs
@@ -40,6 +40,8 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
             return new SftpConnectionTestResult { ProfileFound = false };
         }
 
+        var (encryptedPassword, encryptedPrivateKey, encryptedPrivateKeyPassphrase) =
+            ResolveAuthentication(request, stored);
         var profile = new SftpConnectionProfile
         {
             Id = stored?.Id ?? Guid.Empty,
@@ -47,10 +49,9 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
             Host = request.Host.Trim(),
             Port = request.Port,
             Username = request.Username.Trim(),
-            EncryptedPassword = Protect(request.Password) ?? stored?.EncryptedPassword,
-            EncryptedPrivateKey = Protect(request.PrivateKey) ?? stored?.EncryptedPrivateKey,
-            EncryptedPrivateKeyPassphrase = Protect(request.PrivateKeyPassphrase)
-                ?? stored?.EncryptedPrivateKeyPassphrase,
+            EncryptedPassword = encryptedPassword,
+            EncryptedPrivateKey = encryptedPrivateKey,
+            EncryptedPrivateKeyPassphrase = encryptedPrivateKeyPassphrase,
             HostKeyFingerprintSha256 = ResolveFingerprint(request.HostKeyFingerprintSha256, stored),
             IsDefault = false
         };
@@ -129,6 +130,23 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
 
     private string? Protect(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : _secretProtector.Protect(value);
+
+    private (string? Password, string? PrivateKey, string? Passphrase) ResolveAuthentication(
+        SftpConnectionTestRequest requested,
+        SftpConnectionProfile? stored)
+    {
+        if (requested.AuthenticationMethod == SftpAuthenticationMethod.Password)
+        {
+            return (Protect(requested.Password) ?? stored?.EncryptedPassword, null, null);
+        }
+
+        return (
+            null,
+            Protect(requested.PrivateKey) ?? stored?.EncryptedPrivateKey,
+            requested.RemovePrivateKeyPassphrase
+                ? null
+                : Protect(requested.PrivateKeyPassphrase) ?? stored?.EncryptedPrivateKeyPassphrase);
+    }
 
     private static string? ResolveFingerprint(string? requested, SftpConnectionProfile? stored)
     {

--- a/SporeSync.Business/Service/SftpConnectionTestService.cs
+++ b/SporeSync.Business/Service/SftpConnectionTestService.cs
@@ -40,8 +40,9 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
             return new SftpConnectionTestResult { ProfileFound = false };
         }
 
+        var canReuseStoredCredentials = IsStoredEndpoint(request, stored);
         var (encryptedPassword, encryptedPrivateKey, encryptedPrivateKeyPassphrase) =
-            ResolveAuthentication(request, stored);
+            ResolveAuthentication(request, stored, canReuseStoredCredentials);
         var profile = new SftpConnectionProfile
         {
             Id = stored?.Id ?? Guid.Empty,
@@ -52,7 +53,10 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
             EncryptedPassword = encryptedPassword,
             EncryptedPrivateKey = encryptedPrivateKey,
             EncryptedPrivateKeyPassphrase = encryptedPrivateKeyPassphrase,
-            HostKeyFingerprintSha256 = ResolveFingerprint(request.HostKeyFingerprintSha256, stored),
+            HostKeyFingerprintSha256 = ResolveFingerprint(
+                request.HostKeyFingerprintSha256,
+                stored,
+                canReuseStoredCredentials),
             IsDefault = false
         };
 
@@ -133,30 +137,44 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
 
     private (string? Password, string? PrivateKey, string? Passphrase) ResolveAuthentication(
         SftpConnectionTestRequest requested,
-        SftpConnectionProfile? stored)
+        SftpConnectionProfile? stored,
+        bool canReuseStoredCredentials)
     {
         if (requested.AuthenticationMethod == SftpAuthenticationMethod.Password)
         {
-            return (Protect(requested.Password) ?? stored?.EncryptedPassword, null, null);
+            return (
+                Protect(requested.Password) ?? (canReuseStoredCredentials ? stored?.EncryptedPassword : null),
+                null,
+                null);
         }
 
         return (
             null,
-            Protect(requested.PrivateKey) ?? stored?.EncryptedPrivateKey,
+            Protect(requested.PrivateKey) ?? (canReuseStoredCredentials ? stored?.EncryptedPrivateKey : null),
             requested.RemovePrivateKeyPassphrase
                 ? null
-                : Protect(requested.PrivateKeyPassphrase) ?? stored?.EncryptedPrivateKeyPassphrase);
+                : Protect(requested.PrivateKeyPassphrase) ??
+                  (canReuseStoredCredentials ? stored?.EncryptedPrivateKeyPassphrase : null));
     }
 
-    private static string? ResolveFingerprint(string? requested, SftpConnectionProfile? stored)
+    private static bool IsStoredEndpoint(
+        SftpConnectionTestRequest requested,
+        SftpConnectionProfile? stored) =>
+        stored is not null &&
+        string.Equals(requested.Host.Trim(), stored.Host.Trim(), StringComparison.OrdinalIgnoreCase) &&
+        requested.Port == stored.Port &&
+        string.Equals(requested.Username.Trim(), stored.Username.Trim(), StringComparison.Ordinal);
+
+    private static string? ResolveFingerprint(
+        string? requested,
+        SftpConnectionProfile? stored,
+        bool preserveStoredFingerprint)
     {
-        if (requested is null)
+        if (string.IsNullOrWhiteSpace(requested))
         {
-            return stored?.HostKeyFingerprintSha256;
+            return preserveStoredFingerprint ? stored?.HostKeyFingerprintSha256 : null;
         }
 
-        return string.IsNullOrWhiteSpace(requested)
-            ? null
-            : SshHostKeyFingerprint.Normalize(requested);
+        return SshHostKeyFingerprint.Normalize(requested);
     }
 }

--- a/SporeSync.Business/Service/SftpConnectionTestService.cs
+++ b/SporeSync.Business/Service/SftpConnectionTestService.cs
@@ -1,8 +1,11 @@
 using System.Diagnostics;
+using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
+using Renci.SshNet.Common;
 using SporeSync.Business.Interface;
 using SporeSync.Business.Sftp;
 using SporeSync.Domain.Interface;
+using SporeSync.Domain.Model;
 
 namespace SporeSync.Business.Service;
 
@@ -10,60 +13,128 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
 {
     private readonly ISftpConnectionProfileRepository _profileRepository;
     private readonly ISftpClientFactory _clientFactory;
+    private readonly ISecretProtector _secretProtector;
     private readonly ILogger<SftpConnectionTestService> _logger;
 
     public SftpConnectionTestService(
         ISftpConnectionProfileRepository profileRepository,
         ISftpClientFactory clientFactory,
+        ISecretProtector secretProtector,
         ILogger<SftpConnectionTestService> logger)
     {
         _profileRepository = profileRepository;
         _clientFactory = clientFactory;
+        _secretProtector = secretProtector;
         _logger = logger;
     }
 
     public async Task<SftpConnectionTestResult> TestAsync(
-        Guid profileId,
+        SftpConnectionTestRequest request,
         CancellationToken cancellationToken = default)
     {
-        var profile = await _profileRepository.GetByIdAsync(profileId, cancellationToken);
-        if (profile is null)
+        var stored = request.ProfileId is Guid id
+            ? await _profileRepository.GetByIdAsync(id, cancellationToken)
+            : null;
+        if (request.ProfileId is not null && stored is null)
         {
             return new SftpConnectionTestResult { ProfileFound = false };
         }
 
+        var profile = new SftpConnectionProfile
+        {
+            Id = stored?.Id ?? Guid.Empty,
+            Name = stored?.Name ?? "Connection test",
+            Host = request.Host.Trim(),
+            Port = request.Port,
+            Username = request.Username.Trim(),
+            EncryptedPassword = Protect(request.Password) ?? stored?.EncryptedPassword,
+            EncryptedPrivateKey = Protect(request.PrivateKey) ?? stored?.EncryptedPrivateKey,
+            EncryptedPrivateKeyPassphrase = Protect(request.PrivateKeyPassphrase)
+                ?? stored?.EncryptedPrivateKeyPassphrase,
+            HostKeyFingerprintSha256 = ResolveFingerprint(request.HostKeyFingerprintSha256, stored),
+            IsDefault = false
+        };
+
         var stopwatch = Stopwatch.StartNew();
+        if (string.IsNullOrWhiteSpace(profile.EncryptedPassword) &&
+            string.IsNullOrWhiteSpace(profile.EncryptedPrivateKey))
+        {
+            return Failure("authentication", "Authentication failed. Check the username and credentials.", stopwatch);
+        }
+
         try
         {
-            await using var connected = await _clientFactory.ConnectAsync(profileId, cancellationToken);
-            // Issue one lightweight operation to prove the session is usable beyond the handshake.
-            _ = connected.Client.WorkingDirectory;
-            stopwatch.Stop();
+            await using var connected = await _clientFactory.ConnectAsync(profile, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(request.SourcePath) &&
+                !await connected.Client.ExistsAsync(request.SourcePath.Trim(), cancellationToken))
+            {
+                return Failure("path", "The source path does not exist or is not accessible.", stopwatch);
+            }
 
             return new SftpConnectionTestResult
             {
                 ProfileFound = true,
                 Success = true,
+                Message = string.IsNullOrWhiteSpace(request.SourcePath)
+                    ? "Connection and authentication succeeded."
+                    : "Connection, authentication, and source path check succeeded.",
                 DurationMs = stopwatch.ElapsedMilliseconds
             };
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException)
         {
-            stopwatch.Stop();
-            _logger.LogWarning(
-                ex,
-                "Connection test failed for profile {ProfileId} ({Host}:{Port})",
-                profile.Id,
-                profile.Host,
-                profile.Port);
-
-            return new SftpConnectionTestResult
-            {
-                ProfileFound = true,
-                Success = false,
-                ErrorMessage = ex.Message,
-                DurationMs = stopwatch.ElapsedMilliseconds
-            };
+            throw;
         }
+        catch (SshHostKeyMismatchException)
+        {
+            return Failure("host_key", "The server host key does not match the pinned fingerprint.", stopwatch);
+        }
+        catch (SshAuthenticationException)
+        {
+            return Failure("authentication", "Authentication failed. Check the username and credentials.", stopwatch);
+        }
+        catch (Exception ex) when (ex is SftpPathNotFoundException or SftpPermissionDeniedException)
+        {
+            return Failure("path", "The source path does not exist or is not accessible.", stopwatch);
+        }
+        catch (Exception ex) when (ex is SocketException or SshConnectionException)
+        {
+            return Failure("connection", "Could not connect to the SFTP server.", stopwatch);
+        }
+        catch (SshException)
+        {
+            return Failure("authentication", "Authentication failed. Check the username and credentials.", stopwatch);
+        }
+        catch (Exception)
+        {
+            return Failure("connection", "The SFTP connection test failed.", stopwatch);
+        }
+    }
+
+    private SftpConnectionTestResult Failure(string type, string message, Stopwatch stopwatch)
+    {
+        _logger.LogWarning("SFTP connection test failed with category {FailureType}", type);
+        return new SftpConnectionTestResult
+        {
+            ProfileFound = true,
+            FailureType = type,
+            Message = message,
+            DurationMs = stopwatch.ElapsedMilliseconds
+        };
+    }
+
+    private string? Protect(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : _secretProtector.Protect(value);
+
+    private static string? ResolveFingerprint(string? requested, SftpConnectionProfile? stored)
+    {
+        if (requested is null)
+        {
+            return stored?.HostKeyFingerprintSha256;
+        }
+
+        return string.IsNullOrWhiteSpace(requested)
+            ? null
+            : SshHostKeyFingerprint.Normalize(requested);
     }
 }

--- a/SporeSync.Business/Service/SftpConnectionTestService.cs
+++ b/SporeSync.Business/Service/SftpConnectionTestService.cs
@@ -101,6 +101,10 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
         {
             return Failure("connection", "Could not connect to the SFTP server.", stopwatch);
         }
+        catch (SshOperationTimeoutException)
+        {
+            return Failure("connection", "The SFTP connection or operation timed out.", stopwatch);
+        }
         catch (SshException)
         {
             return Failure("authentication", "Authentication failed. Check the username and credentials.", stopwatch);

--- a/SporeSync.Business/Service/SftpConnectionTestService.cs
+++ b/SporeSync.Business/Service/SftpConnectionTestService.cs
@@ -53,8 +53,9 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
             EncryptedPassword = encryptedPassword,
             EncryptedPrivateKey = encryptedPrivateKey,
             EncryptedPrivateKeyPassphrase = encryptedPrivateKeyPassphrase,
-            HostKeyFingerprintSha256 = ResolveFingerprint(
+            TrustedHostKeyFingerprintsSha256 = ResolveFingerprints(
                 request.HostKeyFingerprintSha256,
+                request.TrustedHostKeyFingerprintsSha256,
                 stored,
                 canReuseStoredCredentials),
             IsDefault = false
@@ -165,16 +166,27 @@ public sealed class SftpConnectionTestService : ISftpConnectionTestService
         requested.Port == stored.Port &&
         string.Equals(requested.Username.Trim(), stored.Username.Trim(), StringComparison.Ordinal);
 
-    private static string? ResolveFingerprint(
+    private static IReadOnlyList<string> ResolveFingerprints(
         string? requested,
+        IReadOnlyList<string>? requestedTrusted,
         SftpConnectionProfile? stored,
         bool preserveStoredFingerprint)
     {
-        if (string.IsNullOrWhiteSpace(requested))
+        if (requestedTrusted is not null)
         {
-            return preserveStoredFingerprint ? stored?.HostKeyFingerprintSha256 : null;
+            return requestedTrusted
+                .Where(fingerprint => !string.IsNullOrWhiteSpace(fingerprint))
+                .Select(SshHostKeyFingerprint.Normalize)
+                .ToArray();
         }
 
-        return SshHostKeyFingerprint.Normalize(requested);
+        if (string.IsNullOrWhiteSpace(requested))
+        {
+            return preserveStoredFingerprint
+                ? stored?.TrustedHostKeyFingerprintsSha256 ?? []
+                : [];
+        }
+
+        return [SshHostKeyFingerprint.Normalize(requested)];
     }
 }

--- a/SporeSync.Business/Sftp/ISftpClientFactory.cs
+++ b/SporeSync.Business/Sftp/ISftpClientFactory.cs
@@ -1,4 +1,5 @@
 using Renci.SshNet;
+using SporeSync.Domain.Model;
 
 namespace SporeSync.Business.Sftp;
 
@@ -7,6 +8,11 @@ public interface ISftpClientFactory
     Task<IConnectedSftpClient> ConnectAsync(
         Guid connectionProfileId,
         CancellationToken cancellationToken = default);
+
+    Task<IConnectedSftpClient> ConnectAsync(
+        SftpConnectionProfile profile,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("Connecting a transient SFTP profile is not supported by this factory.");
 }
 
 public interface IConnectedSftpClient : IAsyncDisposable

--- a/SporeSync.Business/Sftp/SftpClientFactory.cs
+++ b/SporeSync.Business/Sftp/SftpClientFactory.cs
@@ -34,6 +34,21 @@ public sealed class SftpClientFactory : ISftpClientFactory
         var profile = await _profileRepository.GetByIdAsync(connectionProfileId, cancellationToken)
             ?? throw new InvalidOperationException($"SFTP connection profile '{connectionProfileId}' was not found.");
 
+        return await ConnectAsync(profile, persistFirstUseHostKey: true, cancellationToken);
+    }
+
+    public Task<IConnectedSftpClient> ConnectAsync(
+        SftpConnectionProfile profile,
+        CancellationToken cancellationToken = default)
+    {
+        return ConnectAsync(profile, persistFirstUseHostKey: false, cancellationToken);
+    }
+
+    private async Task<IConnectedSftpClient> ConnectAsync(
+        SftpConnectionProfile profile,
+        bool persistFirstUseHostKey,
+        CancellationToken cancellationToken)
+    {
         ConnectionInfo connectionInfo;
         if (!string.IsNullOrWhiteSpace(profile.EncryptedPrivateKey))
         {

--- a/SporeSync.Web/ClientApp/src/api/client.ts
+++ b/SporeSync.Web/ClientApp/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   SporeSyncJob,
   SporeSyncRun,
   StatusResponse,
+  TestSftpConnectionRequest,
   UpsertSftpConnectionProfile,
   UpsertSporeSyncJob,
 } from "./types";
@@ -202,10 +203,10 @@ export const api = {
     fetchNoContent(`/api/sftp-connection-profiles/${id}`, {
       method: "DELETE",
     }),
-  testProfile: (id: string) =>
+  testProfile: (request: TestSftpConnectionRequest) =>
     fetchJson<SftpConnectionTestResponse>(
-      `/api/sftp-connection-profiles/${id}/test`,
-      { method: "POST" },
+      "/api/sftp-connection-profiles/test",
+      { method: "POST", body: JSON.stringify(request) },
     ),
   cancelRun: (id: string) =>
     fetchJson<SporeSyncRun>(`/api/sftp-sync-runs/${id}/cancel`, {

--- a/SporeSync.Web/ClientApp/src/api/types.ts
+++ b/SporeSync.Web/ClientApp/src/api/types.ts
@@ -126,9 +126,11 @@ export interface TestSftpConnectionRequest {
   host: string;
   port: number;
   username: string;
+  authenticationMethod: "password" | "privateKey";
   password?: string | null;
   privateKey?: string | null;
   privateKeyPassphrase?: string | null;
+  removePrivateKeyPassphrase: boolean;
   hostKeyFingerprintSha256?: string | null;
   sourcePath?: string | null;
 }

--- a/SporeSync.Web/ClientApp/src/api/types.ts
+++ b/SporeSync.Web/ClientApp/src/api/types.ts
@@ -116,8 +116,21 @@ export interface AuthSession {
 
 export interface SftpConnectionTestResponse {
   success: boolean;
+  failureType: "connection" | "host_key" | "authentication" | "path" | null;
   message: string | null;
   durationMs: number;
+}
+
+export interface TestSftpConnectionRequest {
+  profileId?: string;
+  host: string;
+  port: number;
+  username: string;
+  password?: string | null;
+  privateKey?: string | null;
+  privateKeyPassphrase?: string | null;
+  hostKeyFingerprintSha256?: string | null;
+  sourcePath?: string | null;
 }
 
 export interface RetryFailedItemsResponse {

--- a/SporeSync.Web/ClientApp/src/api/types.ts
+++ b/SporeSync.Web/ClientApp/src/api/types.ts
@@ -132,6 +132,7 @@ export interface TestSftpConnectionRequest {
   privateKeyPassphrase?: string | null;
   removePrivateKeyPassphrase: boolean;
   hostKeyFingerprintSha256?: string | null;
+  trustedHostKeyFingerprintsSha256?: string[] | null;
   sourcePath?: string | null;
 }
 

--- a/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
@@ -244,7 +244,8 @@ export function ProfilesPage() {
         username: profile.username,
         authenticationMethod: profile.authenticationMethod,
         removePrivateKeyPassphrase: false,
-        hostKeyFingerprintSha256: profile.hostKeyFingerprintSha256,
+        trustedHostKeyFingerprintsSha256:
+          profile.trustedHostKeyFingerprintsSha256,
       }),
     onSuccess: (result, profile) => {
       setTestResults((results) => ({

--- a/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
@@ -242,6 +242,8 @@ export function ProfilesPage() {
         host: profile.host,
         port: profile.port,
         username: profile.username,
+        authenticationMethod: profile.authenticationMethod,
+        removePrivateKeyPassphrase: false,
         hostKeyFingerprintSha256: profile.hostKeyFingerprintSha256,
       }),
     onSuccess: (result, profile) => {
@@ -862,11 +864,13 @@ function ProfileForm({
         host: host.trim(),
         port,
         username: username.trim(),
+        authenticationMethod,
         password: password.trim() ? password : null,
         privateKey: privateKey.trim() ? privateKey : null,
         privateKeyPassphrase: privateKeyPassphrase.trim()
           ? privateKeyPassphrase
           : null,
+        removePrivateKeyPassphrase,
         hostKeyFingerprintSha256:
           hostKeyFingerprints.split(/\s+/).filter(Boolean)[0] ?? "",
         sourcePath: sourcePath.trim() ? sourcePath.trim() : null,

--- a/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
@@ -236,7 +236,14 @@ export function ProfilesPage() {
   });
 
   const testMutation = useMutation({
-    mutationFn: (profile: SftpConnectionProfile) => api.testProfile(profile.id),
+    mutationFn: (profile: SftpConnectionProfile) =>
+      api.testProfile({
+        profileId: profile.id,
+        host: profile.host,
+        port: profile.port,
+        username: profile.username,
+        hostKeyFingerprintSha256: profile.hostKeyFingerprintSha256,
+      }),
     onSuccess: (result, profile) => {
       setTestResults((results) => ({
         ...results,
@@ -834,6 +841,7 @@ function ProfileForm({
   const [hostKeyFingerprints, setHostKeyFingerprints] = useState(
     profile?.trustedHostKeyFingerprintsSha256.join("\n") ?? "",
   );
+  const [sourcePath, setSourcePath] = useState("");
   const [isDefault, setIsDefault] = useState(profile?.isDefault ?? true);
   const preservesSelectedCredential =
     profile?.authenticationMethod === authenticationMethod;
@@ -847,8 +855,24 @@ function ProfileForm({
       );
     },
   });
-  const validation = useMemo(() => {
-    if (!name.trim()) return "Name is required.";
+  const testMutation = useMutation({
+    mutationFn: () =>
+      api.testProfile({
+        profileId: profile?.id,
+        host: host.trim(),
+        port,
+        username: username.trim(),
+        password: password.trim() ? password : null,
+        privateKey: privateKey.trim() ? privateKey : null,
+        privateKeyPassphrase: privateKeyPassphrase.trim()
+          ? privateKeyPassphrase
+          : null,
+        hostKeyFingerprintSha256:
+          hostKeyFingerprints.split(/\s+/).filter(Boolean)[0] ?? "",
+        sourcePath: sourcePath.trim() ? sourcePath.trim() : null,
+      }),
+  });
+  const connectionValidation = useMemo(() => {
     if (!host.trim()) return "Host is required.";
     if (port < 1 || port > 65535) return "Port must be between 1 and 65535.";
     if (!username.trim()) return "Username is required.";
@@ -1041,6 +1065,17 @@ function ProfileForm({
         )}
         <div className="md:col-span-2">
           <Field label="Trusted host key fingerprints (SHA-256, one per line)">
+          <Field label="Source path to check (optional)">
+            <input
+              className={inputClass}
+              placeholder="/upload"
+              value={sourcePath}
+              onChange={(event) => setSourcePath(event.target.value)}
+            />
+          </Field>
+        </div>
+        <div className="md:col-span-2">
+          <Field label="Trusted host key fingerprints (SHA-256, one per line)">
             <div className="flex gap-2">
               <textarea
                 className={`${inputClass} min-h-20 py-2 font-mono text-xs`}
@@ -1092,6 +1127,30 @@ function ProfileForm({
           Blank secret fields keep the currently configured secret.
         </p>
       )}
+      <div className="mt-4 flex items-center gap-3">
+        <Button
+          type="button"
+          disabled={Boolean(connectionValidation) || testMutation.isPending}
+          onClick={() => testMutation.mutate()}
+        >
+          <PlugZap size={16} />
+          {testMutation.isPending ? "Testing…" : "Test Connection"}
+        </Button>
+        {testMutation.data && (
+          <p
+            className={
+              testMutation.data.success
+                ? "text-sm text-emerald-600 dark:text-emerald-300"
+                : "text-sm text-red-600 dark:text-red-300"
+            }
+          >
+            {testMutation.data.message}
+            {testMutation.data.success &&
+              ` (${testMutation.data.durationMs} ms)`}
+          </p>
+        )}
+        {testMutation.error && <ErrorMessage error={testMutation.error} />}
+      </div>
       <FormFooter validation={validation} error={error} isSaving={isSaving} />
     </form>
   );

--- a/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
@@ -892,13 +892,16 @@ function ProfileForm({
   }, [
     authenticationMethod,
     host,
-    name,
     password,
     port,
     preservesSelectedCredential,
     privateKey,
     username,
   ]);
+  const validation = useMemo(() => {
+    if (!name.trim()) return "Name is required.";
+    return connectionValidation;
+  }, [connectionValidation, name]);
 
   return (
     <form

--- a/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
+++ b/SporeSync.Web/ClientApp/src/routes/AdminPages.tsx
@@ -871,8 +871,9 @@ function ProfileForm({
           ? privateKeyPassphrase
           : null,
         removePrivateKeyPassphrase,
-        hostKeyFingerprintSha256:
-          hostKeyFingerprints.split(/\s+/).filter(Boolean)[0] ?? "",
+        trustedHostKeyFingerprintsSha256: hostKeyFingerprints
+          .split(/\s+/)
+          .filter(Boolean),
         sourcePath: sourcePath.trim() ? sourcePath.trim() : null,
       }),
   });
@@ -1071,7 +1072,6 @@ function ProfileForm({
           </>
         )}
         <div className="md:col-span-2">
-          <Field label="Trusted host key fingerprints (SHA-256, one per line)">
           <Field label="Source path to check (optional)">
             <input
               className={inputClass}

--- a/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
+++ b/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
@@ -170,6 +170,10 @@ public sealed class SftpConnectionProfilesController : ControllerBase
         {
             return ValidationProblem(ex.Message);
         }
+        catch (ValidationException ex)
+        {
+            return InvalidProfileRequest(ex);
+        }
 
         if (!result.ProfileFound)
         {

--- a/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
+++ b/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
@@ -157,9 +157,11 @@ public sealed class SftpConnectionProfilesController : ControllerBase
                 Host = request.Host,
                 Port = request.Port,
                 Username = request.Username,
+                AuthenticationMethod = ParseAuthenticationMethod(request.AuthenticationMethod),
                 Password = request.Password,
                 PrivateKey = request.PrivateKey,
                 PrivateKeyPassphrase = request.PrivateKeyPassphrase,
+                RemovePrivateKeyPassphrase = request.RemovePrivateKeyPassphrase,
                 HostKeyFingerprintSha256 = request.HostKeyFingerprintSha256,
                 SourcePath = request.SourcePath
             }, cancellationToken);

--- a/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
+++ b/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
@@ -143,12 +143,32 @@ public sealed class SftpConnectionProfilesController : ControllerBase
         };
     }
 
-    [HttpPost("{id:guid}/test")]
+    [HttpPost("test")]
     public async Task<ActionResult<SftpConnectionTestResponse>> Test(
-        Guid id,
+        TestSftpConnectionRequest request,
         CancellationToken cancellationToken)
     {
-        var result = await _connectionTestService.TestAsync(id, cancellationToken);
+        SftpConnectionTestResult result;
+        try
+        {
+            result = await _connectionTestService.TestAsync(new SftpConnectionTestRequest
+            {
+                ProfileId = request.ProfileId,
+                Host = request.Host,
+                Port = request.Port,
+                Username = request.Username,
+                Password = request.Password,
+                PrivateKey = request.PrivateKey,
+                PrivateKeyPassphrase = request.PrivateKeyPassphrase,
+                HostKeyFingerprintSha256 = request.HostKeyFingerprintSha256,
+                SourcePath = request.SourcePath
+            }, cancellationToken);
+        }
+        catch (FormatException ex)
+        {
+            return ValidationProblem(ex.Message);
+        }
+
         if (!result.ProfileFound)
         {
             return NotFound();
@@ -156,7 +176,8 @@ public sealed class SftpConnectionProfilesController : ControllerBase
 
         return Ok(new SftpConnectionTestResponse(
             result.Success,
-            result.Success ? "Connection succeeded." : result.ErrorMessage,
+            result.FailureType,
+            result.Message,
             result.DurationMs));
     }
 

--- a/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
+++ b/SporeSync.Web/Controllers/SftpConnectionProfilesController.cs
@@ -163,6 +163,7 @@ public sealed class SftpConnectionProfilesController : ControllerBase
                 PrivateKeyPassphrase = request.PrivateKeyPassphrase,
                 RemovePrivateKeyPassphrase = request.RemovePrivateKeyPassphrase,
                 HostKeyFingerprintSha256 = request.HostKeyFingerprintSha256,
+                TrustedHostKeyFingerprintsSha256 = request.TrustedHostKeyFingerprintsSha256,
                 SourcePath = request.SourcePath
             }, cancellationToken);
         }

--- a/SporeSync.Web/DTO/SftpConnectionTestResponse.cs
+++ b/SporeSync.Web/DTO/SftpConnectionTestResponse.cs
@@ -2,5 +2,6 @@ namespace SporeSync.Web.DTO;
 
 public sealed record SftpConnectionTestResponse(
     bool Success,
+    string? FailureType,
     string? Message,
     long DurationMs);

--- a/SporeSync.Web/DTO/TestSftpConnectionRequest.cs
+++ b/SporeSync.Web/DTO/TestSftpConnectionRequest.cs
@@ -13,4 +13,5 @@ public sealed record TestSftpConnectionRequest(
     string? PrivateKeyPassphrase,
     bool RemovePrivateKeyPassphrase,
     [param: MaxLength(100)] string? HostKeyFingerprintSha256,
+    IReadOnlyList<string>? TrustedHostKeyFingerprintsSha256,
     [param: MaxLength(2000)] string? SourcePath);

--- a/SporeSync.Web/DTO/TestSftpConnectionRequest.cs
+++ b/SporeSync.Web/DTO/TestSftpConnectionRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SporeSync.Web.DTO;
+
+public sealed record TestSftpConnectionRequest(
+    Guid? ProfileId,
+    [param: Required, MaxLength(255)] string Host,
+    [param: Range(1, 65535)] int Port,
+    [param: Required, MaxLength(200)] string Username,
+    string? Password,
+    string? PrivateKey,
+    string? PrivateKeyPassphrase,
+    [param: MaxLength(100)] string? HostKeyFingerprintSha256,
+    [param: MaxLength(2000)] string? SourcePath);

--- a/SporeSync.Web/DTO/TestSftpConnectionRequest.cs
+++ b/SporeSync.Web/DTO/TestSftpConnectionRequest.cs
@@ -7,8 +7,10 @@ public sealed record TestSftpConnectionRequest(
     [param: Required, MaxLength(255)] string Host,
     [param: Range(1, 65535)] int Port,
     [param: Required, MaxLength(200)] string Username,
+    [param: Required] string AuthenticationMethod,
     string? Password,
     string? PrivateKey,
     string? PrivateKeyPassphrase,
+    bool RemovePrivateKeyPassphrase,
     [param: MaxLength(100)] string? HostKeyFingerprintSha256,
     [param: MaxLength(2000)] string? SourcePath);


### PR DESCRIPTION
Closes #21

## Summary
- add a non-persisting authenticated connection-test API for unsaved and saved profile form values
- reuse stored credentials when edit-form secret inputs are blank and avoid first-use host-key persistence during tests
- report connection, host-key, authentication, and source-path failures without returning exception or secret material
- add create/edit form Test Connection controls and optional source-path verification
- cover success, failures, stored-secret reuse, non-persistence, timeouts, and cancellation against a real SFTP container

## Validation
- `dotnet build SporeSync.sln` — passed (existing package/analyzer warnings remain)
- `dotnet test SporeSync.sln --no-build` — passed, 262 tests
- `npm run biome:check` — passed
- `npm test` — passed, 27 tests
- live Vite-proxied unsaved test against agent SFTP — passed; profile count remained 0 before and after